### PR TITLE
Removed unused 'self' param from static functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ See also:
 
 ```python
 import openapi_client
-from oauth1.signer_interceptor import add_signing_layer
+from oauth1.signer_interceptor import add_signer_layer
 
 # ...
 config = openapi_client.Configuration()
 config.host = 'https://sandbox.api.mastercard.com'
 client = openapi_client.ApiClient(config)
-add_signing_layer(client, '<insert PKCS#12 key file path>', '<insert key password>', '<insert consumer key>')
+add_signer_layer(client, '<insert PKCS#12 key file path>', '<insert key password>', '<insert consumer key>')
 some_api = openapi_client.SomeApi(client)
 result = some_api.do_something()
 # ...

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ from oauth1.signer_interceptor import add_signing_layer
 config = openapi_client.Configuration()
 config.host = 'https://sandbox.api.mastercard.com'
 client = openapi_client.ApiClient(config)
-add_signing_layer(self, client, '<insert PKCS#12 key file path>', '<insert key password>', '<insert consumer key>')
+add_signing_layer(client, '<insert PKCS#12 key file path>', '<insert key password>', '<insert consumer key>')
 some_api = openapi_client.SomeApi(client)
 result = some_api.do_something()
 # ...

--- a/oauth1/signer_interceptor.py
+++ b/oauth1/signer_interceptor.py
@@ -2,6 +2,8 @@ from functools import wraps
 from oauth1.oauth import OAuth
 from oauth1 import authenticationutils
 from urllib.parse import urlencode
+from deprecated import deprecated
+
 
 class SignerInterceptor(object):
 
@@ -37,11 +39,23 @@ class SignerInterceptor(object):
         request_function.__oauth__ = True
         return request_function
 
-def add_signing_layer(api_client, key_file, key_password, consumer_key):
+
+@deprecated(version='1.1.3', reason="Use add_signer_layer(api_client, key_file, key_password, consumer_key) instead")
+def add_signing_layer(self, api_client, key_file, key_password, consumer_key):
+    add_signer_layer(api_client, key_file, key_password, consumer_key)
+
+
+def add_signer_layer(api_client, key_file, key_password, consumer_key):
     """Create and load configuration. Decorate APIClient.request with header signing"""
 
     api_signer = SignerInterceptor(key_file, key_password, consumer_key)
     api_client.request = api_signer.oauth_signing(api_client.request)
 
-def get_signing_layer(api_client):
+
+@deprecated(version='1.1.3', reason="Use get_signer_layer(api_client) instead")
+def get_signing_layer(self, api_client):
+    return get_signer_layer(api_client)
+
+
+def get_signer_layer(api_client):
     return api_client.request

--- a/oauth1/signer_interceptor.py
+++ b/oauth1/signer_interceptor.py
@@ -37,16 +37,11 @@ class SignerInterceptor(object):
         request_function.__oauth__ = True
         return request_function
 
-def add_signing_layer(self, api_client, key_file, key_password, consumer_key):
+def add_signing_layer(api_client, key_file, key_password, consumer_key):
     """Create and load configuration. Decorate APIClient.request with header signing"""
 
     api_signer = SignerInterceptor(key_file, key_password, consumer_key)
     api_client.request = api_signer.oauth_signing(api_client.request)
 
-def get_signing_layer(self, api_client):
+def get_signing_layer(api_client):
     return api_client.request
-
-
-
- 
- 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cryptography==2.6.1
 pyOpenSSL==19.0.0
 requests==2.22.0
+Deprecated=1.2.5

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(name='mastercard-oauth1-signer',
         'Topic :: Software Development :: Libraries :: Python Modules'
         ],
         tests_require=['coverage'],
-        install_requires=['requests', 'pyOpenSSL', 'urllib3[secure]', 'cryptography']
+        install_requires=['requests', 'pyOpenSSL', 'urllib3[secure]', 'cryptography', 'Deprecated']
 )

--- a/tests/test_interceptor.py
+++ b/tests/test_interceptor.py
@@ -29,8 +29,8 @@
 #
 import unittest
 import requests
-from oauth1.signer_interceptor import add_signing_layer
-from oauth1.signer_interceptor import get_signing_layer
+from oauth1.signer_interceptor import add_signer_layer
+from oauth1.signer_interceptor import get_signer_layer
 
 class OAuthInterceptorTest(unittest.TestCase):
 
@@ -40,9 +40,9 @@ class OAuthInterceptorTest(unittest.TestCase):
         key_password = "Password1"
         consumer_key = 'dummy'
 
-        signing_layer1 = get_signing_layer(requests)
-        add_signing_layer(requests, key_file, key_password, consumer_key)
-        signing_layer2 = get_signing_layer(requests)
+        signing_layer1 = get_signer_layer(requests)
+        add_signer_layer(requests, key_file, key_password, consumer_key)
+        signing_layer2 = get_signer_layer(requests)
         self.assertNotEqual(signing_layer1, signing_layer2)            
 
 if __name__ == '__main__':

--- a/tests/test_interceptor.py
+++ b/tests/test_interceptor.py
@@ -40,9 +40,9 @@ class OAuthInterceptorTest(unittest.TestCase):
         key_password = "Password1"
         consumer_key = 'dummy'
 
-        signing_layer1 = get_signing_layer(self, requests)
-        add_signing_layer(self, requests, key_file, key_password, consumer_key)
-        signing_layer2 = get_signing_layer(self, requests)
+        signing_layer1 = get_signing_layer(requests)
+        add_signing_layer(requests, key_file, key_password, consumer_key)
+        signing_layer2 = get_signing_layer(requests)
         self.assertNotEqual(signing_layer1, signing_layer2)            
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove 'self' param form add_signing_layer and get_signing_layer functions of decorator as they are static