### PR TITLE
Fix OAuth1RSA oauth_body_hash of None body

### DIFF
--- a/oauth1/oauth_ext.py
+++ b/oauth1/oauth_ext.py
@@ -97,10 +97,10 @@ class OAuth1RSA(AuthBase):
             return self.hash_f(message.encode('utf8')).digest()
         elif type(message) is bytes:
             return self.hash_f(message).digest()
-        else:
+        elif not message:
             # Generally for calls where the payload is empty. Eg: get calls
             # Fix for AttributeError: 'NoneType' object has no attribute 'encode'
-            return self.hash_f(str(message).encode('utf8')).digest()
+            return self.hash_f("".encode('utf8')).digest()
 
     @staticmethod
     def signable_message(r: PreparedRequest, payload: dict):

--- a/tests/test_oauth_ext.py
+++ b/tests/test_oauth_ext.py
@@ -109,10 +109,36 @@ class OAuthExtTest(unittest.TestCase):
         oauth_body_hash_object = oauth_object.oauth_body_hash(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload)
 
         # Using mock data to find the hash value
-        hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
+        hashlib_val = hashlib.sha256(str("").encode('utf8')).digest()
         payload_hash_value = util.uri_rfc3986_encode(util.base64_encode(hashlib_val))
 
         self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
+
+    def test_oauth_body_hash_with_body_empty_or_none(self):
+        def prep_request():
+            req = PreparedRequest()
+            req.prepare(headers={'Content-type': 'application/json', 'Accept': 'application/json'},
+                        method="POST",
+                        url="http://www.example.com")
+            return req
+
+        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
+        request_empty = prep_request()
+        request_none = prep_request()
+
+        request_empty.body = ""
+        request_none.body = None
+
+        # Passing data to the actual func to get the value
+        empty_body_hash = oauth_object.oauth_body_hash(request_empty, OAuthExtTest.payload)
+        none_body_hash = oauth_object.oauth_body_hash(request_none, OAuthExtTest.payload)
+
+        # Using mock data to find the hash value
+        empty_string_hash = hashlib.sha256(str("").encode('utf8')).digest()
+        empty_string_encoded = util.uri_rfc3986_encode(util.base64_encode(empty_string_hash))
+
+        self.assertEqual(empty_body_hash['oauth_body_hash'], empty_string_encoded)
+        self.assertEqual(none_body_hash['oauth_body_hash'], empty_string_encoded)
 
     def test_oauth_body_hash_with_body_multipart(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: #32

#### Description
OAuth1RSA created an incorrect hash when the body of a request was None. The problem comes from hashing `str(None)` (== `"None"`) and not the empty string.

Hashed values for `"None"` and `""`:
```
>>> base64.b64encode(hashlib.sha256('None'.encode('utf-8')).digest())
b'3JN7WYkmBPWoaslpNs1/8J4l8Yrmt1joAUokx/oDnpE='
>>> base64.b64encode(hashlib.sha256(''.encode('utf-8')).digest())
b'47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
```
