### PR TITLE
`oauth_signature` not encoded in versions 1.2.0 and 1.3.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,10 @@ name: Linter
 'on':
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     - cron: 0 16 * * *
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Linter
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: 0 16 * * *
+jobs:
+  sonarcloud:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Python Style Checker
+        uses: andymckay/pycodestyle-action@0.1.3

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,12 +2,10 @@ name: Sonar
 'on':
   push:
     branches:
-      - main
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
+      - master
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: 0 16 * * *
 jobs:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,10 +2,10 @@ name: Sonar
 'on':
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     - cron: 0 16 * * *
 jobs:

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ The method that does all the heavy lifting is `OAuth().get_authorization_header`
 ```python
 uri = 'https://sandbox.api.mastercard.com/service'
 payload = 'Hello world!'
-authHeader = OAuth().get_authorization_header(uri, 'POST', payload, '<insert consumer key>', signing_key)
+authHeader = OAuth.get_authorization_header(uri, 'POST', payload, '<insert consumer key>', signing_key)
 ```
 
 #### GET example
 ```python
 uri = 'https://sandbox.api.mastercard.com/service'
-authHeader = OAuth().get_authorization_header(uri, 'GET', None, '<insert consumer key>', signing_key)
+authHeader = OAuth.get_authorization_header(uri, 'GET', None, '<insert consumer key>', signing_key)
 ```
 
 #### Use of authHeader with requests module (POST and GET example)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ signing_key = authenticationutils.load_signing_key('<insert PKCS#12 key file pat
 ```
 
 ### Creating the OAuth Authorization Header <a name="creating-the-oauth-authorization-header"></a>
-The method that does all the heavy lifting is `OAuth().get_authorization_header`. You can call into it directly and as long as you provide the correct parameters, it will return a string that you can add into your request's `Authorization` header.
+The method that does all the heavy lifting is `OAuth.get_authorization_header`. You can call into it directly and as long as you provide the correct parameters, it will return a string that you can add into your request's `Authorization` header.
 
 #### POST example
 

--- a/oauth1/authenticationutils.py
+++ b/oauth1/authenticationutils.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 Mastercard
 # All rights reserved.
@@ -28,10 +27,10 @@
 #
 from OpenSSL import crypto
 
+
 def load_signing_key(pkcs12_filename, password):
     private_key_file = open(pkcs12_filename, 'rb')
     p12 = crypto.load_pkcs12(private_key_file.read(), password.encode("utf-8"))
     private_key = p12.get_privatekey()
     private_key_file.close()
     return private_key
-

--- a/oauth1/authenticationutils.py
+++ b/oauth1/authenticationutils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -32,7 +32,7 @@ import hashlib
 import base64
 import urllib
 import time
-from random import SystemRandom
+from random import randint
 
 from urllib.parse import urlparse, quote, parse_qsl
 
@@ -152,7 +152,7 @@ def get_nonce(length=16):
     """
     characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
     charlen = len(characters)
-    return "".join([characters[SystemRandom().randint(0, charlen - 1)] for _ in range(0, length)])
+    return "".join([characters[randint(0, charlen - 1)] for _ in range(0, length)])
 
 
 def get_timestamp():

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -32,7 +32,7 @@ import hashlib
 import base64
 import urllib
 import time
-from random import randint
+from random import SystemRandom
 
 from urllib.parse import urlparse, quote, parse_qsl
 
@@ -152,7 +152,7 @@ def get_nonce(length=16):
     """
     characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
     charlen = len(characters)
-    return "".join([characters[randint(0, charlen - 1)] for _ in range(0, length)])
+    return "".join([characters[SystemRandom().randint(0, charlen - 1)] for _ in range(0, length)])
 
 
 def get_timestamp():

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -34,7 +34,7 @@ import urllib
 import time
 from random import SystemRandom
 
-from urllib.parse import urlparse, quote, parse_qsl
+from urllib.parse import urlparse, parse_qsl
 
 
 def normalize_params(url, params):
@@ -111,11 +111,10 @@ def base64_encode(text):
     """
     Base64 encodes the given input
     """
+    if not isinstance(text, (bytes, bytearray)):
+        text = bytes(text.encode())
     encode = base64.b64encode(text)
-    if isinstance(encode, (bytearray, bytes)):
-        return encode.decode('ascii')
-    else:
-        return encode
+    return encode.decode('ascii')
 
 
 def percent_encode(text):
@@ -126,8 +125,6 @@ def percent_encode(text):
         return ''
     text = text.encode('utf-8') if isinstance(text, str) else text
     text = urllib.parse.quote(text, safe=b'~')
-    if isinstance(text, bytes):
-        text = text.decode('utf-8')
     return text.replace('+', '%20').replace('*', '%2A').replace('%7E', '~')
 
 

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 Mastercard
 # All rights reserved.
@@ -31,8 +30,11 @@ Utility file having common functions
 """
 import hashlib
 import base64
+import time
+from random import SystemRandom
 
 from urllib.parse import urlparse, quote, parse_qsl
+
 
 def normalize_params(url, params):
     """
@@ -52,7 +54,7 @@ def normalize_params(url, params):
 
     # Needs to be encoded before sorting
     encoded_list = [encode_pair(key, value) for (key, value) in combined_list]
-    sorted_list = sorted(encoded_list, key=lambda x:x)
+    sorted_list = sorted(encoded_list, key=lambda x: x)
 
     return "&".join(sorted_list)
 
@@ -61,6 +63,7 @@ def encode_pair(key, value):
     encoded_key = oauth_query_string_element_encode(key)
     encoded_value = oauth_query_string_element_encode(value if isinstance(value, bytes) else str(value))
     return "%s=%s" % (encoded_key, encoded_value)
+
 
 def oauth_query_string_element_encode(value):
     """
@@ -75,6 +78,7 @@ def oauth_query_string_element_encode(value):
     encoded = str.replace(encoded, '*', '%2A')
     return encoded
 
+
 def normalize_url(url):
     """
     Removes the query parameters from the URL
@@ -83,16 +87,16 @@ def normalize_url(url):
 
     # netloc should be lowercase
     netloc = parse.netloc.lower()
-    if parse.scheme=="http":
+    if parse.scheme == "http":
         if netloc.endswith(":80"):
             netloc = netloc[:-3]
 
-    elif parse.scheme=="https" and netloc.endswith(":443"):
+    elif parse.scheme == "https" and netloc.endswith(":443"):
         netloc = netloc[:-4]
 
     # add a '/' at the end of the netloc if there in no path
     if not parse.path:
-        netloc = netloc+"/"
+        netloc = netloc + "/"
 
     return "{}://{}{}".format(parse.scheme, netloc, parse.path)
 
@@ -120,3 +124,19 @@ def base64_encode(text):
         return encode.decode('ascii')
     else:
         return encode
+
+
+def get_nonce(length=16):
+    """
+    Returns a random string of length=@length
+    """
+    characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    charlen = len(characters)
+    return "".join([characters[SystemRandom().randint(0, charlen - 1)] for _ in range(0, length)])
+
+
+def get_timestamp():
+    """
+    Returns the UTC timestamp (seconds passed since epoch)
+    """
+    return int(time.time())

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -68,20 +68,6 @@ def encode_pair(must_encode, key, value):
     return encoded_key, encoded_value
 
 
-def oauth_query_string_element_encode(value):
-    """
-    RFC 3986 encodes the value
-
-    Note. This is based on RFC3986 but according to https://tools.ietf.org/html/rfc5849#section-3.6
-    it replaces space with %20 not "+".
-    """
-    encoded = quote(value)
-    encoded = str.replace(encoded, ':', '%3A')
-    encoded = str.replace(encoded, '+', '%2B')
-    encoded = str.replace(encoded, '*', '%2A')
-    return encoded
-
-
 def normalize_url(url):
     """
     Removes the query parameters from the URL

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/oauth1/coreutils.py
+++ b/oauth1/coreutils.py
@@ -37,129 +37,126 @@ from random import SystemRandom
 from urllib.parse import urlparse, quote, parse_qsl
 
 
-class CoreUtils:
+def normalize_params(url, params):
+    """
+    Combines the query parameters of url and extra params into a single queryString.
+    All the query string parameters are lexicographically sorted
+    """
+    # parse the url
+    parse = urlparse(url)
 
-    @staticmethod
-    def normalize_params(url, params):
-        """
-        Combines the query parameters of url and extra params into a single queryString.
-        All the query string parameters are lexicographically sorted
-        """
-        # parse the url
-        parse = urlparse(url)
+    # Get the query list
+    qs_list = parse_qsl(parse.query, keep_blank_values=True)
+    if params is None:
+        combined_list = qs_list
+    else:
+        # Needs to be encoded before sorting
+        combined_list = [encode_pair(key, value) for (key, value) in list(qs_list)]
+        combined_list += params.items()
 
-        # Get the query list
-        qs_list = parse_qsl(parse.query, keep_blank_values=True)
-        if params is None:
-            combined_list = qs_list
-        else:
-            # Needs to be encoded before sorting
-            combined_list = [CoreUtils.encode_pair(key, value) for (key, value) in list(qs_list)]
-            combined_list += params.items()
+    encoded_list = ["%s=%s" % (key, value) for (key, value) in combined_list]
+    sorted_list = sorted(encoded_list, key=lambda x: x)
 
-        encoded_list = ["%s=%s" % (key, value) for (key, value) in combined_list]
-        sorted_list = sorted(encoded_list, key=lambda x: x)
+    return "&".join(sorted_list)
 
-        return "&".join(sorted_list)
 
-    @staticmethod
-    def encode_pair(key, value):
-        encoded_key = CoreUtils.oauth_query_string_element_encode(key)
-        encoded_value = CoreUtils.oauth_query_string_element_encode(value if isinstance(value, bytes) else str(value))
-        return encoded_key, encoded_value
+def encode_pair(key, value):
+    encoded_key = oauth_query_string_element_encode(key)
+    encoded_value = oauth_query_string_element_encode(value if isinstance(value, bytes) else str(value))
+    return encoded_key, encoded_value
 
-    @staticmethod
-    def oauth_query_string_element_encode(value):
-        """
-        RFC 3986 encodes the value
 
-        Note. This is based on RFC3986 but according to https://tools.ietf.org/html/rfc5849#section-3.6
-        it replaces space with %20 not "+".
-        """
-        encoded = quote(value)
-        encoded = str.replace(encoded, ':', '%3A')
-        encoded = str.replace(encoded, '+', '%2B')
-        encoded = str.replace(encoded, '*', '%2A')
-        return encoded
+def oauth_query_string_element_encode(value):
+    """
+    RFC 3986 encodes the value
 
-    @staticmethod
-    def normalize_url(url):
-        """
-        Removes the query parameters from the URL
-        """
-        parse = urlparse(url)
+    Note. This is based on RFC3986 but according to https://tools.ietf.org/html/rfc5849#section-3.6
+    it replaces space with %20 not "+".
+    """
+    encoded = quote(value)
+    encoded = str.replace(encoded, ':', '%3A')
+    encoded = str.replace(encoded, '+', '%2B')
+    encoded = str.replace(encoded, '*', '%2A')
+    return encoded
 
-        # netloc should be lowercase
-        netloc = parse.netloc.lower()
-        if parse.scheme == "http":
-            if netloc.endswith(":80"):
-                netloc = netloc[:-3]
 
-        elif parse.scheme == "https" and netloc.endswith(":443"):
-            netloc = netloc[:-4]
+def normalize_url(url):
+    """
+    Removes the query parameters from the URL
+    """
+    parse = urlparse(url)
 
-        # add a '/' at the end of the netloc if there in no path
-        if not parse.path:
-            netloc = netloc + "/"
+    # netloc should be lowercase
+    netloc = parse.netloc.lower()
+    if parse.scheme == "http":
+        if netloc.endswith(":80"):
+            netloc = netloc[:-3]
 
-        return "{}://{}{}".format(parse.scheme, netloc, parse.path)
+    elif parse.scheme == "https" and netloc.endswith(":443"):
+        netloc = netloc[:-4]
 
-    @staticmethod
-    def uri_rfc3986_encode(value):
-        """
-        RFC 3986 encodes the value
-        """
-        return quote(value, safe='%')
+    # add a '/' at the end of the netloc if there in no path
+    if not parse.path:
+        netloc = netloc + "/"
 
-    @staticmethod
-    def sha256_encode(text):
-        """
-        Returns the digest of SHA-256 of the text
-        """
-        _hash = hashlib.sha256
-        if type(text) is str:
-            return _hash(text.encode('utf8')).digest()
-        elif type(text) is bytes:
-            return _hash(text).digest()
-        elif not text:
-            # Generally for calls where the payload is empty. Eg: get calls
-            # Fix for AttributeError: 'NoneType' object has no attribute 'encode'
-            return _hash("".encode('utf8')).digest()
-        else:
-            return _hash(str(text).encode('utf-8')).digest()
+    return "{}://{}{}".format(parse.scheme, netloc, parse.path)
 
-    @staticmethod
-    def base64_encode(text):
-        """
-        Base64 encodes the given input
-        """
-        encode = base64.b64encode(text)
-        if isinstance(encode, (bytearray, bytes)):
-            return encode.decode('ascii')
-        else:
-            return encode
 
-    @staticmethod
-    def percent_encode(text):
-        """
-        Percent encodes a string as per https://tools.ietf.org/html/rfc3986
-        """
-        if text is None:
-            return ''
-        return urllib.parse.quote_plus(text).replace('+', '%20').replace('*', '%2A').replace('%7E', '~')
+def uri_rfc3986_encode(value):
+    """
+    RFC 3986 encodes the value
+    """
+    return quote(value, safe='%')
 
-    @staticmethod
-    def get_nonce(length=16):
-        """
-        Returns a random string of length=@length
-        """
-        characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        charlen = len(characters)
-        return "".join([characters[SystemRandom().randint(0, charlen - 1)] for _ in range(0, length)])
 
-    @staticmethod
-    def get_timestamp():
-        """
-        Returns the UTC timestamp (seconds passed since epoch)
-        """
-        return int(time.time())
+def sha256_encode(text):
+    """
+    Returns the digest of SHA-256 of the text
+    """
+    _hash = hashlib.sha256
+    if type(text) is str:
+        return _hash(text.encode('utf8')).digest()
+    elif type(text) is bytes:
+        return _hash(text).digest()
+    elif not text:
+        # Generally for calls where the payload is empty. Eg: get calls
+        # Fix for AttributeError: 'NoneType' object has no attribute 'encode'
+        return _hash("".encode('utf8')).digest()
+    else:
+        return _hash(str(text).encode('utf-8')).digest()
+
+
+def base64_encode(text):
+    """
+    Base64 encodes the given input
+    """
+    encode = base64.b64encode(text)
+    if isinstance(encode, (bytearray, bytes)):
+        return encode.decode('ascii')
+    else:
+        return encode
+
+
+def percent_encode(text):
+    """
+    Percent encodes a string as per https://tools.ietf.org/html/rfc3986
+    """
+    if text is None:
+        return ''
+    return urllib.parse.quote_plus(text).replace('+', '%20').replace('*', '%2A').replace('%7E', '~')
+
+
+def get_nonce(length=16):
+    """
+    Returns a random string of length=@length
+    """
+    characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    charlen = len(characters)
+    return "".join([characters[SystemRandom().randint(0, charlen - 1)] for _ in range(0, length)])
+
+
+def get_timestamp():
+    """
+    Returns the UTC timestamp (seconds passed since epoch)
+    """
+    return int(time.time())

--- a/oauth1/oauth.py
+++ b/oauth1/oauth.py
@@ -41,7 +41,8 @@ class OAuth:
         oauth_base_parameters_dict = oauth_parameters.get_base_parameters_dict()
 
         # Generate the header value for OAuth Header
-        oauth_key = OAuthParameters.OAUTH_KEY + " " + ",".join([str(key) + "=\"" + str(value) + "\"" for (key, value) in oauth_base_parameters_dict.items()])
+        oauth_key = OAuthParameters.OAUTH_KEY + " " + ",".join(
+            [str(key) + "=\"" + str(value) + "\"" for (key, value) in oauth_base_parameters_dict.items()])
         return oauth_key
 
     @staticmethod
@@ -69,7 +70,7 @@ class OAuth:
         signature = OAuth.sign_message(base_string, signing_key)
 
         # Set the signature in the Base parameters
-        oauth_parameters.set_oauth_signature(util.uri_rfc3986_encode(signature))
+        oauth_parameters.set_oauth_signature(util.percent_encode(signature))
 
         return oauth_parameters
 

--- a/oauth1/oauth.py
+++ b/oauth1/oauth.py
@@ -26,8 +26,9 @@
 # SUCH DAMAGE.
 #
 import json
-import oauth1.coreutils as util
 from OpenSSL import crypto
+
+from oauth1.coreutils import CoreUtils
 
 
 class OAuth:
@@ -49,8 +50,8 @@ class OAuth:
         # Get all the base parameters such as nonce and timestamp
         oauth_parameters = OAuthParameters()
         oauth_parameters.set_oauth_consumer_key(consumer_key)
-        oauth_parameters.set_oauth_nonce(util.get_nonce())
-        oauth_parameters.set_oauth_timestamp(util.get_timestamp())
+        oauth_parameters.set_oauth_nonce(CoreUtils.get_nonce())
+        oauth_parameters.set_oauth_timestamp(CoreUtils.get_timestamp())
         oauth_parameters.set_oauth_signature_method("RSA-SHA256")
         oauth_parameters.set_oauth_version("1.0")
 
@@ -59,7 +60,7 @@ class OAuth:
             # If the request does not have an entity body, the hash should be taken over the empty string
             payload_str = OAuth.EMPTY_STRING
 
-        encoded_hash = util.base64_encode(util.sha256_encode(payload_str))
+        encoded_hash = CoreUtils.base64_encode(CoreUtils.sha256_encode(payload_str))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
 
         # Get the base string
@@ -69,7 +70,7 @@ class OAuth:
         signature = OAuth.sign_message(base_string, signing_key)
 
         # Set the signature in the Base parameters
-        oauth_parameters.set_oauth_signature(util.uri_rfc3986_encode(signature))
+        oauth_parameters.set_oauth_signature(CoreUtils.uri_rfc3986_encode(signature))
 
         return oauth_parameters
 
@@ -77,14 +78,14 @@ class OAuth:
     def get_base_string(url, method, oauth_parameters):
         merge_params = oauth_parameters.copy()
         return "{}&{}&{}".format(method.upper(),
-                                 util.percent_encode(util.normalize_url(url)),
-                                 util.percent_encode(util.normalize_params(url, merge_params)))
+                                 CoreUtils.percent_encode(CoreUtils.normalize_url(url)),
+                                 CoreUtils.percent_encode(CoreUtils.normalize_params(url, merge_params)))
 
     @staticmethod
     def sign_message(message, signing_key):
         #    Signs the message using the private signing key
         sign = crypto.sign(signing_key, message.encode("utf-8"), 'SHA256')
-        return util.base64_encode(sign)
+        return CoreUtils.base64_encode(sign)
 
 
 class OAuthParameters(object):

--- a/oauth1/oauth.py
+++ b/oauth1/oauth.py
@@ -26,9 +26,8 @@
 # SUCH DAMAGE.
 #
 import json
+import oauth1.coreutils as util
 from OpenSSL import crypto
-
-from oauth1.coreutils import CoreUtils
 
 
 class OAuth:
@@ -50,8 +49,8 @@ class OAuth:
         # Get all the base parameters such as nonce and timestamp
         oauth_parameters = OAuthParameters()
         oauth_parameters.set_oauth_consumer_key(consumer_key)
-        oauth_parameters.set_oauth_nonce(CoreUtils.get_nonce())
-        oauth_parameters.set_oauth_timestamp(CoreUtils.get_timestamp())
+        oauth_parameters.set_oauth_nonce(util.get_nonce())
+        oauth_parameters.set_oauth_timestamp(util.get_timestamp())
         oauth_parameters.set_oauth_signature_method("RSA-SHA256")
         oauth_parameters.set_oauth_version("1.0")
 
@@ -60,7 +59,7 @@ class OAuth:
             # If the request does not have an entity body, the hash should be taken over the empty string
             payload_str = OAuth.EMPTY_STRING
 
-        encoded_hash = CoreUtils.base64_encode(CoreUtils.sha256_encode(payload_str))
+        encoded_hash = util.base64_encode(util.sha256_encode(payload_str))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
 
         # Get the base string
@@ -70,7 +69,7 @@ class OAuth:
         signature = OAuth.sign_message(base_string, signing_key)
 
         # Set the signature in the Base parameters
-        oauth_parameters.set_oauth_signature(CoreUtils.uri_rfc3986_encode(signature))
+        oauth_parameters.set_oauth_signature(util.uri_rfc3986_encode(signature))
 
         return oauth_parameters
 
@@ -78,14 +77,14 @@ class OAuth:
     def get_base_string(url, method, oauth_parameters):
         merge_params = oauth_parameters.copy()
         return "{}&{}&{}".format(method.upper(),
-                                 CoreUtils.percent_encode(CoreUtils.normalize_url(url)),
-                                 CoreUtils.percent_encode(CoreUtils.normalize_params(url, merge_params)))
+                                 util.percent_encode(util.normalize_url(url)),
+                                 util.percent_encode(util.normalize_params(url, merge_params)))
 
     @staticmethod
     def sign_message(message, signing_key):
         #    Signs the message using the private signing key
         sign = crypto.sign(signing_key, message.encode("utf-8"), 'SHA256')
-        return CoreUtils.base64_encode(sign)
+        return util.base64_encode(sign)
 
 
 class OAuthParameters(object):

--- a/oauth1/oauth.py
+++ b/oauth1/oauth.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/oauth1/oauth.py
+++ b/oauth1/oauth.py
@@ -76,9 +76,9 @@ class OAuth:
     @staticmethod
     def get_base_string(url, method, oauth_parameters):
         merge_params = oauth_parameters.copy()
-        return "{}&{}&{}".format(util.uri_rfc3986_encode(method.upper()),
-                                 util.uri_rfc3986_encode(util.normalize_url(url)),
-                                 util.uri_rfc3986_encode(util.normalize_params(url, merge_params)))
+        return "{}&{}&{}".format(method.upper(),
+                                 util.percent_encode(util.normalize_url(url)),
+                                 util.percent_encode(util.normalize_params(url, merge_params)))
 
     @staticmethod
     def sign_message(message, signing_key):

--- a/oauth1/oauth_ext.py
+++ b/oauth1/oauth_ext.py
@@ -49,7 +49,7 @@ class OAuth1RSA(AuthBase):
         self.signing_key = signing_key
 
     def __call__(self, r: PreparedRequest):
-        method = '' if r.method is None else r.method.upper()
+        method = r.method.upper() if r.method is not None else r.method
         if all(v is not None for v in [r, self.consumer_key, self.signing_key]):
             r.headers['Authorization'] = \
                 OAuth.get_authorization_header(uri=r.url,

--- a/oauth1/oauth_ext.py
+++ b/oauth1/oauth_ext.py
@@ -49,10 +49,12 @@ class OAuth1RSA(AuthBase):
         self.signing_key = signing_key
 
     def __call__(self, r: PreparedRequest):
-        r.headers['Authorization'] = \
-            OAuth.get_authorization_header(uri=r.url,
-                                           method=r.method.upper(),
-                                           payload=r.body,
-                                           consumer_key=self.consumer_key,
-                                           signing_key=self.signing_key)
+        method = '' if r.method is None else r.method.upper()
+        if all(v is not None for v in [r, self.consumer_key, self.signing_key]):
+            r.headers['Authorization'] = \
+                OAuth.get_authorization_header(uri=r.url,
+                                               method=method,
+                                               payload=r.body,
+                                               consumer_key=self.consumer_key,
+                                               signing_key=self.signing_key)
         return r

--- a/oauth1/oauth_ext.py
+++ b/oauth1/oauth_ext.py
@@ -25,27 +25,18 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
-from requests.auth import AuthBase
 from OpenSSL.crypto import PKey
-from OpenSSL import crypto
 from requests import PreparedRequest
-import hashlib
-from . import coreutils as util
+from requests.auth import AuthBase
 
-HASH_SHA256 = 'SHA256'
-
-
-def hash_func(hash_alg):
-    return {
-        HASH_SHA256: hashlib.sha256
-    }[hash_alg]
+from .oauth import OAuth
 
 
 class OAuth1RSA(AuthBase):
     """OAuth1 RSA-SHA256 requests's auth helper
     Usage:
         >>> from oauth1 import authenticationutils
-        >>> from oauth1.auth_ext import OAuth1RSA
+        >>> from oauth1.oauth_ext import OAuth1RSA
         >>> import requests
         >>> CONSUMER_KEY = 'secret-consumer-key'
         >>> pk = authenticationutils.load_signing_key('instance/masterpass.pfx', 'a3fa02536a')
@@ -56,64 +47,12 @@ class OAuth1RSA(AuthBase):
     def __init__(self, consumer_key: str, signing_key: PKey):
         self.consumer_key = consumer_key
         self.signing_key = signing_key
-        self.hash_alg = HASH_SHA256
-        self.hash_f = hash_func(HASH_SHA256)
 
     def __call__(self, r: PreparedRequest):
-        payload = {
-            'oauth_version': '1.0',
-            'oauth_nonce': util.get_nonce(),
-            'oauth_timestamp': util.get_timestamp(),
-            'oauth_signature_method': f'RSA-{self.hash_alg}',
-            'oauth_consumer_key': self.consumer_key
-        }
-
-        # Google's body hash extension
-        payload = self.oauth_body_hash(r, payload)
-
-        signable_message = self.signable_message(r, payload)
-        signature = self.signature(signable_message)
-        payload['oauth_signature'] = util.uri_rfc3986_encode(signature)
-
-        h = self._generate_header(payload)
-
-        r.headers['Authorization'] = h
+        r.headers['Authorization'] = \
+            OAuth.get_authorization_header(uri=r.url,
+                                           method=r.method.upper(),
+                                           payload=r.body,
+                                           consumer_key=self.consumer_key,
+                                           signing_key=self.signing_key)
         return r
-
-    def _hash(self, message: str) -> bytes:
-        if type(message) is str:
-            return self.hash_f(message.encode('utf8')).digest()
-        elif type(message) is bytes:
-            return self.hash_f(message).digest()
-        elif not message:
-            # Generally for calls where the payload is empty. Eg: get calls
-            # Fix for AttributeError: 'NoneType' object has no attribute 'encode'
-            return self.hash_f("".encode('utf8')).digest()
-
-    @staticmethod
-    def signable_message(r: PreparedRequest, payload: dict):
-        params = [
-            r.method.upper(),
-            util.normalize_url(r.url),
-            util.normalize_params(r.url, payload)
-        ]
-        params = map(util.uri_rfc3986_encode, params)
-        return '&'.join(params)
-
-    def signature(self, message: str):
-        signature = crypto.sign(self.signing_key, message, self.hash_alg)
-        return util.base64_encode(signature)
-
-    @staticmethod
-    def _generate_header(payload: dict):
-        pts = [f'{k}="{v}"' for k, v in sorted(payload.items())]
-        msg = ','.join(pts)
-        return f'OAuth {msg}'
-
-    def oauth_body_hash(self, r: PreparedRequest, payload: dict):
-        if r.headers and r.headers.get('content-type') == 'multipart/form-data':
-            return payload
-
-        body = r.body
-        payload['oauth_body_hash'] = util.base64_encode(self._hash(body))
-        return payload

--- a/oauth1/signer.py
+++ b/oauth1/signer.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 Mastercard
 # All rights reserved.
@@ -28,7 +27,8 @@
 #
 from oauth1.oauth import OAuth
 
-class OAuthSigner():
+
+class OAuthSigner:
 
     def __init__(self, consumer_key, signing_key):
         self.consumer_key = consumer_key
@@ -36,7 +36,7 @@ class OAuthSigner():
 
     def sign_request(self, uri, request):
         #  Generates the OAuth header for the request, adds the header to the request and returns the request object
-        oauth_key = OAuth().get_authorization_header(uri, request.method, request.data, self.consumer_key, self.signing_key)
+        oauth_key = OAuth.get_authorization_header(uri, request.method, request.data, self.consumer_key,
+                                                   self.signing_key)
         request.headers["Authorization"] = oauth_key
         return request
-

--- a/oauth1/signer.py
+++ b/oauth1/signer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/oauth1/signer_interceptor.py
+++ b/oauth1/signer_interceptor.py
@@ -1,3 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019-2020 Mastercard
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list of
+# conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials
+# provided with the distribution.
+# Neither the name of the MasterCard International Incorporated nor the names of its
+# contributors may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
 from functools import wraps
 from oauth1.oauth import OAuth
 from oauth1 import authenticationutils
@@ -24,8 +51,7 @@ class SignerInterceptor(object):
             if query_params:
                 uri += '?' + urlencode(query_params)
 
-            auth_header = OAuth().get_authorization_header(uri, args[0], in_body,
-                                                           self.consumer_key, self.signing_key)
+            auth_header = OAuth.get_authorization_header(uri, args[0], in_body, self.consumer_key, self.signing_key)
 
             in_headers = kwargs.get("headers", None)
             if not in_headers:

--- a/oauth1/signer_interceptor.py
+++ b/oauth1/signer_interceptor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/oauth1/version.py
+++ b/oauth1/version.py
@@ -1,3 +1,2 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 __version__ = '1.4.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 #
 # Redistribution and use in source and binary forms, with or without modification, are
 # permitted provided that the following conditions are met:

--- a/tests/test_interceptor.py
+++ b/tests/test_interceptor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-#
 #
 #
@@ -32,9 +31,10 @@ import requests
 from oauth1.signer_interceptor import add_signer_layer
 from oauth1.signer_interceptor import get_signer_layer
 
-class OAuthInterceptorTest(unittest.TestCase):
 
+class OAuthInterceptorTest(unittest.TestCase):
     """ add an interceptor, check api client has changed """
+
     def test_add_interceptor(self):
         key_file = './test_key_container.p12'
         key_password = "Password1"
@@ -43,7 +43,8 @@ class OAuthInterceptorTest(unittest.TestCase):
         signing_layer1 = get_signer_layer(requests)
         add_signer_layer(requests, key_file, key_password, consumer_key)
         signing_layer2 = get_signer_layer(requests)
-        self.assertNotEqual(signing_layer1, signing_layer2)            
+        self.assertNotEqual(signing_layer1, signing_layer2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_interceptor.py
+++ b/tests/test_interceptor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-#
 #
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -26,7 +26,10 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
+import multiprocessing
 import unittest
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 import oauth1.authenticationutils as authenticationutils
@@ -34,12 +37,9 @@ import oauth1.coreutils as util
 from oauth1.oauth import OAuth
 from oauth1.oauth import OAuthParameters
 
-from concurrent.futures import ThreadPoolExecutor
-import multiprocessing
-
 
 class OAuthTest(unittest.TestCase):
-    signing_key = authenticationutils.load_signing_key('./test_key_container.p12', "Password1")
+    signing_key = authenticationutils.load_signing_key('../test_key_container.p12', "Password1")
     uri = 'https://www.example.com'
 
     def test_get_authorization_header_nominal(self):
@@ -122,16 +122,10 @@ class OAuthTest(unittest.TestCase):
         future = executor.submit(task)
         future.result()
 
-        self.assertEqual(OAuthTest.list_duplicates(list_of_nonce), [])
+        counter = Counter(list_of_nonce)
+        res = [k for k, v in counter.items() if v > 1]
 
-    @staticmethod
-    def list_duplicates(seq):
-        seen = set()
-        seen_add = seen.add
-        # adds all elements it doesn't know yet to seen and all other to seen_twice
-        seen_twice = set(x for x in seq if x in seen or seen_add(x))
-        # turn the set into a list (as requested)
-        return list(seen_twice)
+        self.assertEqual(len(res), 0)
 
     def test_params_string_rfc_example_1(self):
         uri = "https://sandbox.api.mastercard.com"

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -272,7 +272,7 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         encoded_hash = util.base64_encode(util.sha256_encode(None))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
-        self.assertEqual("3JN7WYkmBPWoaslpNs1/8J4l8Yrmt1joAUokx/oDnpE=", encoded_hash)
+        self.assertEqual("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", encoded_hash)
 
     def test_body_hash3(self):
         oauth_parameters = OAuthParameters()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -39,7 +39,7 @@ from oauth1.oauth import OAuthParameters
 
 
 class OAuthTest(unittest.TestCase):
-    signing_key = authenticationutils.load_signing_key('../test_key_container.p12', "Password1")
+    signing_key = authenticationutils.load_signing_key('./test_key_container.p12', "Password1")
     uri = 'https://www.example.com'
 
     def test_get_authorization_header_nominal(self):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -32,7 +32,7 @@ from unittest.mock import MagicMock
 
 import oauth1.authenticationutils as authenticationutils
 import oauth1.coreutils as util
-from oauth1.coreutils import get_nonce
+from importlib import reload
 from oauth1.oauth import OAuth
 from oauth1.oauth import OAuthParameters
 
@@ -114,7 +114,7 @@ class OAuthTest(unittest.TestCase):
         list_of_nonce = []
 
         for _ in range(0, 100000):
-            list_of_nonce.append(get_nonce())
+            list_of_nonce.append(util.get_nonce())
 
         counter = Counter(list_of_nonce)
         res = [k for k, v in counter.items() if v > 1]
@@ -345,7 +345,7 @@ class OAuthTest(unittest.TestCase):
         auth_header = OAuth.get_authorization_header('https://api.mastercard.com/abc/%123/service?a=123&b=%2a2b3',
                                                      'GET', None,
                                                      'abc-abc-abc!123', OAuthTest.signing_key)
-
+        reload(util)
         self.assertEqual('OAuth oauth_consumer_key="abc-abc-abc!123",oauth_nonce="Wpe3LF09z1e3xQRI",'
                          'oauth_timestamp="1626728330",oauth_signature_method="RSA-SHA256",oauth_version="1.0",'
                          'oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",'
@@ -362,7 +362,7 @@ class OAuthTest(unittest.TestCase):
         auth_header = OAuth.get_authorization_header(url,
                                                      'GET', None,
                                                      'abc-abc-abc!123', OAuthTest.signing_key)
-
+        reload(util)
         self.assertEqual('OAuth oauth_consumer_key="abc-abc-abc!123",oauth_nonce="Wpe3LF09z1e3xQRI",'
                          'oauth_timestamp="1626728330",oauth_signature_method="RSA-SHA256",oauth_version="1.0",'
                          'oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",'
@@ -379,7 +379,7 @@ class OAuthTest(unittest.TestCase):
         auth_header = OAuth.get_authorization_header(url,
                                                      'GET', None,
                                                      'abc-abc-abc!123', OAuthTest.signing_key)
-
+        reload(util)
         self.assertEqual('OAuth oauth_consumer_key="abc-abc-abc!123",oauth_nonce="Wpe3LF09z1e3xQRI",'
                          'oauth_timestamp="1626728330",oauth_signature_method="RSA-SHA256",oauth_version="1.0",'
                          'oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",'
@@ -397,7 +397,7 @@ class OAuthTest(unittest.TestCase):
         auth_header = OAuth.get_authorization_header(url,
                                                      'GET', None,
                                                      'abc-abc-abc!123', OAuthTest.signing_key)
-
+        reload(util)
         self.assertEqual('OAuth oauth_consumer_key="abc-abc-abc!123",oauth_nonce="Wpe3LF09z1e3xQRI",'
                          'oauth_timestamp="1626728330",oauth_signature_method="RSA-SHA256",oauth_version="1.0",'
                          'oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",'
@@ -415,7 +415,7 @@ class OAuthTest(unittest.TestCase):
         auth_header = OAuth.get_authorization_header(url,
                                                      'GET', None,
                                                      'abc-abc-abc!123', OAuthTest.signing_key)
-
+        reload(util)
         self.assertEqual('OAuth oauth_consumer_key="abc-abc-abc!123",oauth_nonce="Wpe3LF09z1e3xQRI",'
                          'oauth_timestamp="1626728330",oauth_signature_method="RSA-SHA256",oauth_version="1.0",'
                          'oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",'
@@ -436,6 +436,17 @@ class OAuthTest(unittest.TestCase):
             'abc%21123%26oauth_nonce%3DWpe3LF09z1e3xQRI%26oauth_signature_method%3DRSA-SHA256%26oauth_timestamp%3D1626'
             '728330%26oauth_version%3D1.0%26param%3Dtoken1%3Atoken2',
             encoded)
+
+    def test_sha256_encoding_when_no_str_or_byte(self):
+        val = util.sha256_encode(123)
+        self.assertEqual(b'\xa6e\xa4Y B/\x9dA~Hg\xef\xdcO\xb8\xa0J\x1f?\xff\x1f\xa0~\x99\x8e\x86\xf7\xf7\xa2z\xe3', val)
+
+    def test_percent_encoding_of_None(self):
+        self.assertEqual('', util.percent_encode(None))
+
+    def test_string_b64_encoding(self):
+        t = util.base64_encode('foo bar foo bar')
+        self.assertEqual('Zm9vIGJhciBmb28gYmFy', t)
 
 
 if __name__ == '__main__':

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -336,11 +336,11 @@ class OAuthTest(unittest.TestCase):
         self.assertTrue("dummy" in header)
 
     def test_percent_encoding(self):
-        self.assertEquals("Format%3DXML", util.percent_encode("Format=XML"))
-        self.assertEquals("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
-        self.assertEquals("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
-        self.assertEquals("WhqqH%2BTU95VgZ~Itpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZ~Itpdq78BWb4cE=&o"))
-        self.assertEquals("%2525%C2%A3%C2%A5a%2FEl%20Ni%C3%B1o%2F%25", util.percent_encode("%25£¥a/El Niño/%"))
+        self.assertEqual("Format%3DXML", util.percent_encode("Format=XML"))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+        self.assertEqual("WhqqH%2BTU95VgZ~Itpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZ~Itpdq78BWb4cE=&o"))
+        self.assertEqual("%2525%C2%A3%C2%A5a%2FEl%20Ni%C3%B1o%2F%25", util.percent_encode("%25£¥a/El Niño/%"))
 
     def test_valid_oauth_signature_with_percent(self):
         util.get_nonce = MagicMock(return_value='Wpe3LF09z1e3xQRI')

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-#
 #
 #
@@ -32,44 +31,53 @@ from oauth1.oauth import OAuth
 from oauth1.oauth import OAuthParameters
 import oauth1.authenticationutils as authenticationutils
 import oauth1.coreutils as Util
-from oauth1.signer import OAuthSigner
+
 
 class OAuthTest(unittest.TestCase):
-
     signing_key = authenticationutils.load_signing_key('./test_key_container.p12', "Password1")
     uri = 'https://www.example.com'
 
     def test_get_authorization_header_nominal(self):
-        header = OAuth().get_authorization_header(OAuthTest.uri, 'POST', 'payload', 'dummy', OAuthTest.signing_key)
+        header = OAuth.get_authorization_header(OAuthTest.uri, 'POST', 'payload', 'dummy', OAuthTest.signing_key)
         self.assertTrue("OAuth" in header)
         self.assertTrue("dummy" in header)
 
     def test_get_authorization_header_should_compute_body_hash(self):
-        header = OAuth().get_authorization_header(OAuthTest.uri, 'POST', '{}', 'dummy', OAuthTest.signing_key)
+        header = OAuth.get_authorization_header(OAuthTest.uri, 'POST', '{}', 'dummy', OAuthTest.signing_key)
         self.assertTrue('RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o=' in header)
 
     def test_get_authorization_header_should_return_empty_string_body_hash(self):
-        header = OAuth().get_authorization_header(OAuthTest.uri, 'GET', None, 'dummy', OAuthTest.signing_key)
+        header = OAuth.get_authorization_header(OAuthTest.uri, 'GET', None, 'dummy', OAuthTest.signing_key)
         self.assertTrue('47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' in header)
 
     def test_get_nonce(self):
-        nonce = OAuth.get_nonce(self)
-        self.assertEqual(len(nonce),16)
+        nonce = Util.get_nonce()
+        self.assertEqual(len(nonce), 16)
 
     def test_get_timestamp(self):
-        timestamp = OAuth.get_timestamp(self)
-        self.assertEqual(len(str(timestamp)),10)
+        timestamp = Util.get_timestamp()
+        self.assertEqual(len(str(timestamp)), 10)
 
     def test_sign_message(self):
-        base_string = 'POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3DWhqqH%252BTU95VgZMItpdq78BWb4cE%253D%26oauth_consumer_key%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0'
-        signature = OAuth().sign_message(base_string, OAuthTest.signing_key)
+        base_string = 'POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry' \
+                      '&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3DWhqqH' \
+                      '%252BTU95VgZMItpdq78BWb4cE%253D%26oauth_consumer_key' \
+                      '%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111' \
+                      '%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0'
+        signature = OAuth.sign_message(base_string, OAuthTest.signing_key)
         signature = Util.uri_rfc3986_encode(signature)
-        self.assertEqual(signature,"DvyS3R795sUb%2FcvBfiFYZzPDU%2BRVefW6X%2BAfyu%2B9fxjudQft%2BShXhpounzJxYCwOkkjZWXOR0ICTMn6MOuG04TTtmPMrOxj5feGwD3leMBsi%2B3XxcFLPi8BhZKqgapcAqlGfjEhq0COZ%2FF9aYDcjswLu0zgrTMSTp4cqXYMr9mbQVB4HL%2FjiHni5ejQu9f6JB9wWW%2BLXYhe8F6b4niETtzIe5o77%2B%2BkKK67v9wFIZ9pgREz7ug8K5DlxX0DuwdUKFhsenA5z%2FNNCZrJE%2BtLu0tSjuF5Gsjw5GRrvW33MSoZ0AYfeleh5V3nLGgHrhVjl5%2BiS40pnG2po%2F5hIAUT5ag%3D%3D")
+        self.assertEqual(signature,
+                         "DvyS3R795sUb%2FcvBfiFYZzPDU%2BRVefW6X%2BAfyu%2B9fxjudQft"
+                         "%2BShXhpounzJxYCwOkkjZWXOR0ICTMn6MOuG04TTtmPMrOxj5feGwD3leMBsi"
+                         "%2B3XxcFLPi8BhZKqgapcAqlGfjEhq0COZ%2FF9aYDcjswLu0zgrTMSTp4cqXYMr9mbQVB4HL"
+                         "%2FjiHni5ejQu9f6JB9wWW%2BLXYhe8F6b4niETtzIe5o77%2B"
+                         "%2BkKK67v9wFIZ9pgREz7ug8K5DlxX0DuwdUKFhsenA5z%2FNNCZrJE"
+                         "%2BtLu0tSjuF5Gsjw5GRrvW33MSoZ0AYfeleh5V3nLGgHrhVjl5%2BiS40pnG2po%2F5hIAUT5ag%3D%3D")
 
     def test_oauth_parameters(self):
         uri = "https://sandbox.api.mastercard.com/fraud/merchant/v1/termination-inquiry?Format=XML&PageOffset=0"
         method = "POST"
-        parameters = OAuth().get_oauth_parameters(uri, method, 'payload', 'dummy', OAuthTest.signing_key)
+        parameters = OAuth.get_oauth_parameters(uri, method, 'payload', 'dummy', OAuthTest.signing_key)
         consumer_key = parameters.get_oauth_consumer_key()
         self.assertEqual("dummy", consumer_key)
 
@@ -81,6 +89,11 @@ class OAuthTest(unittest.TestCase):
         query_params = Util.normalize_params(uri, merge_parameters)
         self.assertEqual(query_params, "empty=&length=10&odd=&offset=0&offset=1")
 
+    def test_query_parser_when_params_is_None(self):
+        uri = "https://sandbox.api.mastercard.com/audiences/v1/getcountries"
+        query_params = Util.normalize_params(uri, None)
+        self.assertEqual(query_params, '')
+
     def test_query_parser_encoding(self):
         uri = "https://sandbox.api.mastercard.com?param1=plus+value&param2=colon:value"
         oauth_parameters = OAuthParameters()
@@ -90,14 +103,14 @@ class OAuthTest(unittest.TestCase):
         self.assertEqual(query_params, "param1=plus%20value&param2=colon%3Avalue")
 
     def test_nonce_length(self):
-        nonce = OAuth.get_nonce(self)
+        nonce = Util.get_nonce()
         self.assertEqual(16, len(nonce))
 
     def test_nonce_uniqueness(self):
-        init = OAuth.get_nonce(self)
+        init = Util.get_nonce()
         l = []
-        for _ in range(0,100000):
-            l.append(init +  OAuth.get_nonce(self))
+        for _ in range(0, 100000):
+            l.append(init + Util.get_nonce())
 
         self.assertEqual(self.list_duplicates(l), [])
 
@@ -105,9 +118,9 @@ class OAuthTest(unittest.TestCase):
         seen = set()
         seen_add = seen.add
         # adds all elements it doesn't know yet to seen and all other to seen_twice
-        seen_twice = set( x for x in seq if x in seen or seen_add(x) )
+        seen_twice = set(x for x in seq if x in seen or seen_add(x))
         # turn the set into a list (as requested)
-        return list( seen_twice )
+        return list(seen_twice)
 
     def test_params_string_rfc_example_1(self):
         uri = "https://sandbox.api.mastercard.com"
@@ -122,7 +135,10 @@ class OAuthTest(unittest.TestCase):
         merge_parameters1 = oauth_parameters_base1.copy()
         query_params1 = Util.normalize_params(uri, merge_parameters1)
 
-        self.assertEqual("oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131201", query_params1);
+        self.assertEqual(
+            "oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1"
+            "&oauth_timestamp=137131201",
+            query_params1)
 
     def test_params_string_rfc_example_2(self):
         uri = "https://sandbox.api.mastercard.com?b5=%3D%253D&a3=a&a3=2%20q&c%40=&a2=r%20b&c2="
@@ -152,12 +168,25 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters.set_oauth_body_hash("body/hash")
         oauth_parameters.set_oauth_nonce("randomnonce")
 
-        base_string = OAuth.get_base_string(self, base_uri, "POST", oauth_parameters.get_base_parameters_dict())
-        self.assertEqual("POST&https%3A%2F%2Fapi.mastercard.com%2F&oauth_body_hash%3Dbody%2Fhash%26oauth_nonce%3Drandomnonce", base_string);
+        base_string = OAuth.get_base_string(base_uri, "POST", oauth_parameters.get_base_parameters_dict())
+        self.assertEqual(
+            "POST&https%3A%2F%2Fapi.mastercard.com%2F&oauth_body_hash%3Dbody%2Fhash%26oauth_nonce%3Drandomnonce",
+            base_string)
 
     def test_signature_base_string2(self):
-        body = "<?xml version=\"1.0\" encoding=\"Windows-1252\"?><ns2:TerminationInquiryRequest xmlns:ns2=\"http://mastercard.com/termination\"><AcquirerId>1996</AcquirerId><TransactionReferenceNumber>1</TransactionReferenceNumber><Merchant><Name>TEST</Name><DoingBusinessAsName>TEST</DoingBusinessAsName><PhoneNumber>5555555555</PhoneNumber><NationalTaxId>1234567890</NationalTaxId><Address><Line1>5555 Test Lane</Line1><City>TEST</City><CountrySubdivision>XX</CountrySubdivision><PostalCode>12345</PostalCode><Country>USA</Country></Address><Principal><FirstName>John</FirstName><LastName>Smith</LastName><NationalId>1234567890</NationalId><PhoneNumber>5555555555</PhoneNumber><Address><Line1>5555 Test Lane</Line1><City>TEST</City><CountrySubdivision>XX</CountrySubdivision><PostalCode>12345</PostalCode><Country>USA</Country></Address><DriversLicense><Number>1234567890</Number><CountrySubdivision>XX</CountrySubdivision></DriversLicense></Principal></Merchant></ns2:TerminationInquiryRequest>";
-        url = "https://sandbox.api.mastercard.com/fraud/merchant/v1/termination-inquiry?Format=XML&PageOffset=0&PageLength=10"
+        body = "<?xml version=\"1.0\" encoding=\"Windows-1252\"?><ns2:TerminationInquiryRequest " \
+               "xmlns:ns2=\"http://mastercard.com/termination\"><AcquirerId>1996</AcquirerId" \
+               "><TransactionReferenceNumber>1</TransactionReferenceNumber><Merchant><Name>TEST</Name" \
+               "><DoingBusinessAsName>TEST</DoingBusinessAsName><PhoneNumber>5555555555</PhoneNumber><NationalTaxId" \
+               ">1234567890</NationalTaxId><Address><Line1>5555 Test " \
+               "Lane</Line1><City>TEST</City><CountrySubdivision>XX</CountrySubdivision><PostalCode>12345</PostalCode" \
+               "><Country>USA</Country></Address><Principal><FirstName>John</FirstName><LastName>Smith</LastName" \
+               "><NationalId>1234567890</NationalId><PhoneNumber>5555555555</PhoneNumber><Address><Line1>5555 Test " \
+               "Lane</Line1><City>TEST</City><CountrySubdivision>XX</CountrySubdivision><PostalCode>12345</PostalCode" \
+               "><Country>USA</Country></Address><DriversLicense><Number>1234567890</Number><CountrySubdivision>XX" \
+               "</CountrySubdivision></DriversLicense></Principal></Merchant></ns2:TerminationInquiryRequest>"
+        url = "https://sandbox.api.mastercard.com/fraud/merchant/v1/termination-inquiry?Format=XML&PageOffset=0" \
+              "&PageLength=10"
         method = "POST"
 
         oauth_parameters = OAuthParameters()
@@ -169,17 +198,26 @@ class OAuthTest(unittest.TestCase):
         encoded_hash = Util.base64_encode(Util.sha256_encode(body))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
 
-        base_string = OAuth.get_base_string(self, url, method, oauth_parameters.get_base_parameters_dict())
-        expected = "POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3Dh2Pd7zlzEZjZVIKB4j94UZn%2FxxoR3RoCjYQ9%2FJdadGQ%3D%26oauth_consumer_key%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0"
+        base_string = OAuth.get_base_string(url, method, oauth_parameters.get_base_parameters_dict())
+        expected = "POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry" \
+                   "&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3Dh2Pd7zlzEZjZVIKB4j94UZn" \
+                   "%2FxxoR3RoCjYQ9%2FJdadGQ%3D%26oauth_consumer_key" \
+                   "%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111" \
+                   "%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0"
 
-        self.assertEqual(expected, base_string);
+        self.assertEqual(expected, base_string)
 
     def test_sign_signature_base_string_invalid_key(self):
-        self.assertRaises(AttributeError, OAuth.sign_message, self, "some string", None)
+        self.assertRaises(AttributeError, OAuth.sign_message, "some string", None)
 
     def test_sign_signature_base_string(self):
-        expected_signature_string = "IJeNKYGfUhFtj5OAPRI92uwfjJJLCej3RCMLbp7R6OIYJhtwxnTkloHQ2bgV7fks4GT/A7rkqrgUGk0ewbwIC6nS3piJHyKVc7rvQXZuCQeeeQpFzLRiH3rsb+ZS+AULK+jzDje4Fb+BQR6XmxuuJmY6YrAKkj13Ln4K6bZJlSxOizbNvt+Htnx+hNd4VgaVBeJKcLhHfZbWQxK76nMnjY7nDcM/2R6LUIR2oLG1L9m55WP3bakAvmOr392ulv1+mWCwDAZZzQ4lakDD2BTu0ZaVsvBW+mcKFxYeTq7SyTQMM4lEwFPJ6RLc8jJJ+veJXHekLVzWg4qHRtzNBLz1mA=="
-        signing_string = OAuth.sign_message(self, "baseString", OAuthTest.signing_key)
+        expected_signature_string = "IJeNKYGfUhFtj5OAPRI92uwfjJJLCej3RCMLbp7R6OIYJhtwxnTkloHQ2bgV7fks4GT" \
+                                    "/A7rkqrgUGk0ewbwIC6nS3piJHyKVc7rvQXZuCQeeeQpFzLRiH3rsb+ZS+AULK+jzDje4Fb" \
+                                    "+BQR6XmxuuJmY6YrAKkj13Ln4K6bZJlSxOizbNvt+Htnx" \
+                                    "+hNd4VgaVBeJKcLhHfZbWQxK76nMnjY7nDcM/2R6LUIR2oLG1L9m55WP3bakAvmOr392ulv1" \
+                                    "+mWCwDAZZzQ4lakDD2BTu0ZaVsvBW+mcKFxYeTq7SyTQMM4lEwFPJ6RLc8jJJ" \
+                                    "+veJXHekLVzWg4qHRtzNBLz1mA=="
+        signing_string = OAuth.sign_message("baseString", OAuthTest.signing_key)
         self.assertEqual(expected_signature_string, signing_string)
 
     def test_url_normalization_rfc_examples1(self):
@@ -190,7 +228,7 @@ class OAuthTest(unittest.TestCase):
     def test_url_normalization_rfc_examples2(self):
         uri = "http://EXAMPLE.COM:80/r%20v/X?id=123"
         base_uri = Util.normalize_url(uri)
-        self.assertEqual("http://example.com/r%20v/X", base_uri);
+        self.assertEqual("http://example.com/r%20v/X", base_uri)
 
     def test_url_normalization_redundant_ports1(self):
         uri = "https://api.mastercard.com:443/test?query=param"
@@ -210,12 +248,12 @@ class OAuthTest(unittest.TestCase):
     def test_url_normalization_remove_fragment(self):
         uri = "https://api.mastercard.com/test?query=param#fragment"
         base_uri = Util.normalize_url(uri)
-        self.assertEqual("https://api.mastercard.com/test", base_uri);
+        self.assertEqual("https://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_add_trailing_slash(self):
         uri = "https://api.mastercard.com"
         base_uri = Util.normalize_url(uri)
-        self.assertEqual("https://api.mastercard.com/", base_uri);
+        self.assertEqual("https://api.mastercard.com/", base_uri)
 
     def test_url_normalization_lowercase_scheme_and_host(self):
         uri = "HTTPS://API.MASTERCARD.COM/TEST"
@@ -245,8 +283,55 @@ class OAuthTest(unittest.TestCase):
 
     def test_url_encode2(self):
         self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", Util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
+
     def test_url_encode3(self):
-        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o", Util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o",
+                         Util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+
+    def test_get_oauth_nonce_param(self):
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.put(OAuthParameters.OAUTH_NONCE_KEY, "abcde")
+        val = oauth_parameters.get_oauth_nonce()
+        self.assertEqual("abcde", val)
+
+    def test_get_oauth_nonce_timestamp_param(self):
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.put(OAuthParameters.OAUTH_TIMESTAMP_KEY, "abcde")
+        val = oauth_parameters.get_oauth_timestamp()
+        self.assertEqual("abcde", val)
+
+    def test_get_oauth_signature_method_param(self):
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.put(OAuthParameters.OAUTH_SIGNATURE_METHOD_KEY, "abcde")
+        val = oauth_parameters.get_oauth_signature_method()
+        self.assertEqual("abcde", val)
+
+    def test_get_oauth_signature_param(self):
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.put(OAuthParameters.OAUTH_SIGNATURE_KEY, "abcde")
+        val = oauth_parameters.get_oauth_signature()
+        self.assertEqual("abcde", val)
+
+    def test_get_oauth_body_hash_param(self):
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.put(OAuthParameters.OAUTH_BODY_HASH_KEY, "abcde")
+        val = oauth_parameters.get_oauth_body_hash()
+        self.assertEqual("abcde", val)
+
+    def test_get_oauth_version_param(self):
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.put(OAuthParameters.OAUTH_VERSION, "abcde")
+        val = oauth_parameters.get_oauth_version()
+        self.assertEqual("abcde", val)
+
+    def test_backward_compatibility_with_static_method(self):
+        header = OAuth().get_authorization_header(OAuthTest.uri, 'POST', 'payload', 'dummy', OAuthTest.signing_key)
+        self.assertTrue("OAuth" in header)
+        self.assertTrue("dummy" in header)
+
+        header = OAuth.get_authorization_header(OAuthTest.uri, 'POST', 'payload', 'dummy', OAuthTest.signing_key)
+        self.assertTrue("OAuth" in header)
+        self.assertTrue("dummy" in header)
 
 
 if __name__ == '__main__':

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -27,10 +27,12 @@
 # SUCH DAMAGE.
 #
 import unittest
+from unittest.mock import MagicMock
+
+import oauth1.authenticationutils as authenticationutils
+import oauth1.coreutils as util
 from oauth1.oauth import OAuth
 from oauth1.oauth import OAuthParameters
-import oauth1.authenticationutils as authenticationutils
-import oauth1.coreutils as Util
 
 
 class OAuthTest(unittest.TestCase):
@@ -51,11 +53,11 @@ class OAuthTest(unittest.TestCase):
         self.assertTrue('47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' in header)
 
     def test_get_nonce(self):
-        nonce = Util.get_nonce()
+        nonce = util.get_nonce()
         self.assertEqual(len(nonce), 16)
 
     def test_get_timestamp(self):
-        timestamp = Util.get_timestamp()
+        timestamp = util.get_timestamp()
         self.assertEqual(len(str(timestamp)), 10)
 
     def test_sign_message(self):
@@ -65,7 +67,7 @@ class OAuthTest(unittest.TestCase):
                       '%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111' \
                       '%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0'
         signature = OAuth.sign_message(base_string, OAuthTest.signing_key)
-        signature = Util.uri_rfc3986_encode(signature)
+        signature = util.uri_rfc3986_encode(signature)
         self.assertEqual(signature,
                          "DvyS3R795sUb%2FcvBfiFYZzPDU%2BRVefW6X%2BAfyu%2B9fxjudQft"
                          "%2BShXhpounzJxYCwOkkjZWXOR0ICTMn6MOuG04TTtmPMrOxj5feGwD3leMBsi"
@@ -86,12 +88,12 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         oauth_parameters_base = oauth_parameters.get_base_parameters_dict()
         merge_parameters = oauth_parameters_base.copy()
-        query_params = Util.normalize_params(uri, merge_parameters)
+        query_params = util.normalize_params(uri, merge_parameters)
         self.assertEqual(query_params, "empty=&length=10&odd=&offset=0&offset=1")
 
     def test_query_parser_when_params_is_None(self):
         uri = "https://sandbox.api.mastercard.com/audiences/v1/getcountries"
-        query_params = Util.normalize_params(uri, None)
+        query_params = util.normalize_params(uri, None)
         self.assertEqual(query_params, '')
 
     def test_query_parser_encoding(self):
@@ -99,18 +101,18 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         oauth_parameters_base = oauth_parameters.get_base_parameters_dict()
         merge_parameters = oauth_parameters_base.copy()
-        query_params = Util.normalize_params(uri, merge_parameters)
+        query_params = util.normalize_params(uri, merge_parameters)
         self.assertEqual(query_params, "param1=plus%20value&param2=colon%3Avalue")
 
     def test_nonce_length(self):
-        nonce = Util.get_nonce()
+        nonce = util.get_nonce()
         self.assertEqual(16, len(nonce))
 
     def test_nonce_uniqueness(self):
-        init = Util.get_nonce()
+        init = util.get_nonce()
         l = []
         for _ in range(0, 100000):
-            l.append(init + Util.get_nonce())
+            l.append(init + util.get_nonce())
 
         self.assertEqual(self.list_duplicates(l), [])
 
@@ -133,7 +135,7 @@ class OAuthTest(unittest.TestCase):
 
         oauth_parameters_base1 = oauth_parameters1.get_base_parameters_dict()
         merge_parameters1 = oauth_parameters_base1.copy()
-        query_params1 = Util.normalize_params(uri, merge_parameters1)
+        query_params1 = util.normalize_params(uri, merge_parameters1)
 
         self.assertEqual(
             "oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1"
@@ -146,7 +148,7 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters2 = OAuthParameters()
         oauth_parameters_base2 = oauth_parameters2.get_base_parameters_dict()
         merge_parameters2 = oauth_parameters_base2.copy()
-        query_params2 = Util.normalize_params(uri, merge_parameters2)
+        query_params2 = util.normalize_params(uri, merge_parameters2)
 
         self.assertEqual("a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=", query_params2)
 
@@ -156,13 +158,13 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         oauth_parameters_base = oauth_parameters.get_base_parameters_dict()
         merge_parameters = oauth_parameters_base.copy()
-        norm_params = Util.normalize_params(url, merge_parameters)
+        norm_params = util.normalize_params(url, merge_parameters)
 
         self.assertEqual("0=0&A=A&A=a&B=B&a=A&a=a&b=b", norm_params)
 
     def test_signature_base_string(self):
         uri = "https://api.mastercard.com"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
 
         oauth_parameters = OAuthParameters()
         oauth_parameters.set_oauth_body_hash("body/hash")
@@ -195,7 +197,7 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters.set_oauth_timestamp("1111111111")
         oauth_parameters.set_oauth_version("1.0")
         oauth_parameters.set_oauth_body_hash("body/hash")
-        encoded_hash = Util.base64_encode(Util.sha256_encode(body))
+        encoded_hash = util.base64_encode(util.sha256_encode(body))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
 
         base_string = OAuth.get_base_string(url, method, oauth_parameters.get_base_parameters_dict())
@@ -222,71 +224,71 @@ class OAuthTest(unittest.TestCase):
 
     def test_url_normalization_rfc_examples1(self):
         uri = "https://www.example.net:8080"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("https://www.example.net:8080/", base_uri)
 
     def test_url_normalization_rfc_examples2(self):
         uri = "http://EXAMPLE.COM:80/r%20v/X?id=123"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("http://example.com/r%20v/X", base_uri)
 
     def test_url_normalization_redundant_ports1(self):
         uri = "https://api.mastercard.com:443/test?query=param"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_redundant_ports2(self):
         uri = "http://api.mastercard.com:80/test"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("http://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_redundant_ports3(self):
         uri = "https://api.mastercard.com:17443/test?query=param"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com:17443/test", base_uri)
 
     def test_url_normalization_remove_fragment(self):
         uri = "https://api.mastercard.com/test?query=param#fragment"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_add_trailing_slash(self):
         uri = "https://api.mastercard.com"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/", base_uri)
 
     def test_url_normalization_lowercase_scheme_and_host(self):
         uri = "HTTPS://API.MASTERCARD.COM/TEST"
-        base_uri = Util.normalize_url(uri)
+        base_uri = util.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/TEST", base_uri)
 
     def test_body_hash1(self):
         oauth_parameters = OAuthParameters()
-        encoded_hash = Util.base64_encode(Util.sha256_encode(OAuth.EMPTY_STRING))
+        encoded_hash = util.base64_encode(util.sha256_encode(OAuth.EMPTY_STRING))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
         self.assertEqual("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", encoded_hash)
 
     def test_body_hash2(self):
         oauth_parameters = OAuthParameters()
-        encoded_hash = Util.base64_encode(Util.sha256_encode(None))
+        encoded_hash = util.base64_encode(util.sha256_encode(None))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
         self.assertEqual("3JN7WYkmBPWoaslpNs1/8J4l8Yrmt1joAUokx/oDnpE=", encoded_hash)
 
     def test_body_hash3(self):
         oauth_parameters = OAuthParameters()
-        encoded_hash = Util.base64_encode(Util.sha256_encode("{\"foõ\":\"bar\"}"))
+        encoded_hash = util.base64_encode(util.sha256_encode("{\"foõ\":\"bar\"}"))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
         self.assertEqual("+Z+PWW2TJDnPvRcTgol+nKO3LT7xm8smnsg+//XMIyI=", encoded_hash)
 
     def test_url_encode1(self):
-        self.assertEqual("Format%3DXML", Util.uri_rfc3986_encode("Format=XML"))
+        self.assertEqual("Format%3DXML", util.uri_rfc3986_encode("Format=XML"))
 
     def test_url_encode2(self):
-        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", Util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
 
     def test_url_encode3(self):
         self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o",
-                         Util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+                         util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
 
     def test_get_oauth_nonce_param(self):
         oauth_parameters = OAuthParameters()
@@ -332,6 +334,29 @@ class OAuthTest(unittest.TestCase):
         header = OAuth.get_authorization_header(OAuthTest.uri, 'POST', 'payload', 'dummy', OAuthTest.signing_key)
         self.assertTrue("OAuth" in header)
         self.assertTrue("dummy" in header)
+
+    def test_percent_encoding(self):
+        self.assertEquals("Format%3DXML", util.percent_encode("Format=XML"))
+        self.assertEquals("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
+        self.assertEquals("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+        self.assertEquals("WhqqH%2BTU95VgZ~Itpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZ~Itpdq78BWb4cE=&o"))
+        self.assertEquals("%2525%C2%A3%C2%A5a%2FEl%20Ni%C3%B1o%2F%25", util.percent_encode("%25£¥a/El Niño/%"))
+
+    def test_valid_oauth_signature_with_percent(self):
+        util.get_nonce = MagicMock(return_value='Wpe3LF09z1e3xQRI')
+        util.get_timestamp = MagicMock(return_value=1626728330)
+        auth_header = OAuth.get_authorization_header('https://api.mastercard.com/abc/%123/service?a=123&b=%2a2b3',
+                                                     'GET', None,
+                                                     'abc-abc-abc!123', OAuthTest.signing_key)
+
+        self.assertEqual('OAuth oauth_consumer_key="abc-abc-abc!123",oauth_nonce="Wpe3LF09z1e3xQRI",'
+                         'oauth_timestamp="1626728330",oauth_signature_method="RSA-SHA256",oauth_version="1.0",'
+                         'oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",'
+                         'oauth_signature="GFdvCNe14%2FQdPi6KLgdFtYnqz9QVsqlzRwT1P5wvZCgyBzfTol69SRz4cIkeDx'
+                         '%2BIEeUfkbrPdVA9JPy0S9lgpMzs0KfIAX064Bz5mBbTni8NWD74ulN5eEDQRWB47BqEsvNPSJlJLGapVe'
+                         'YFyRlcIU7xMU1e1lA%2FtPTTHDSmIBfq4CtpCPvYMcd7ywoiHsi4hfI0d%2BTGS9pe0ez00mkne8C3%2FAHt'
+                         'uRIp564D02Hhl6s%2BTUGdUvlXTaFaIH9GVdZ15n%2FUcTCqSKFjorwA9guiJQlFpZtQy04BBD19VbN6%2F%2BS'
+                         'JvMAnVFQM5FJhgZ%2F5T9OP9%2BmjXz47EhG9MAx3raBjIw%3D%3D"', auth_header)
 
 
 if __name__ == '__main__':

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -33,7 +33,7 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 import oauth1.authenticationutils as authenticationutils
-import oauth1.coreutils as util
+from oauth1.coreutils import CoreUtils
 from oauth1.oauth import OAuth
 from oauth1.oauth import OAuthParameters
 
@@ -56,11 +56,11 @@ class OAuthTest(unittest.TestCase):
         self.assertTrue('47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' in header)
 
     def test_get_nonce(self):
-        nonce = util.get_nonce()
+        nonce = CoreUtils.get_nonce()
         self.assertEqual(len(nonce), 16)
 
     def test_get_timestamp(self):
-        timestamp = util.get_timestamp()
+        timestamp = CoreUtils.get_timestamp()
         self.assertEqual(len(str(timestamp)), 10)
 
     def test_sign_message(self):
@@ -70,7 +70,7 @@ class OAuthTest(unittest.TestCase):
                       '%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111' \
                       '%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0'
         signature = OAuth.sign_message(base_string, OAuthTest.signing_key)
-        signature = util.uri_rfc3986_encode(signature)
+        signature = CoreUtils.uri_rfc3986_encode(signature)
         self.assertEqual(signature,
                          "DvyS3R795sUb%2FcvBfiFYZzPDU%2BRVefW6X%2BAfyu%2B9fxjudQft"
                          "%2BShXhpounzJxYCwOkkjZWXOR0ICTMn6MOuG04TTtmPMrOxj5feGwD3leMBsi"
@@ -91,12 +91,12 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         oauth_parameters_base = oauth_parameters.get_base_parameters_dict()
         merge_parameters = oauth_parameters_base.copy()
-        query_params = util.normalize_params(uri, merge_parameters)
+        query_params = CoreUtils.normalize_params(uri, merge_parameters)
         self.assertEqual(query_params, "empty=&length=10&odd=&offset=0&offset=1")
 
     def test_query_parser_when_params_is_None(self):
         uri = "https://sandbox.api.mastercard.com/audiences/v1/getcountries"
-        query_params = util.normalize_params(uri, None)
+        query_params = CoreUtils.normalize_params(uri, None)
         self.assertEqual(query_params, '')
 
     def test_query_parser_encoding(self):
@@ -104,11 +104,11 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         oauth_parameters_base = oauth_parameters.get_base_parameters_dict()
         merge_parameters = oauth_parameters_base.copy()
-        query_params = util.normalize_params(uri, merge_parameters)
+        query_params = CoreUtils.normalize_params(uri, merge_parameters)
         self.assertEqual(query_params, "param1=plus%20value&param2=colon%3Avalue")
 
     def test_nonce_length(self):
-        nonce = util.get_nonce()
+        nonce = CoreUtils.get_nonce()
         self.assertEqual(16, len(nonce))
 
     def test_nonce_uniqueness(self):
@@ -116,7 +116,7 @@ class OAuthTest(unittest.TestCase):
 
         def task():
             for _ in range(0, 100000):
-                list_of_nonce.append(util.get_nonce())
+                list_of_nonce.append(CoreUtils.get_nonce())
 
         executor = ThreadPoolExecutor(multiprocessing.cpu_count())
         future = executor.submit(task)
@@ -138,7 +138,7 @@ class OAuthTest(unittest.TestCase):
 
         oauth_parameters_base1 = oauth_parameters1.get_base_parameters_dict()
         merge_parameters1 = oauth_parameters_base1.copy()
-        query_params1 = util.normalize_params(uri, merge_parameters1)
+        query_params1 = CoreUtils.normalize_params(uri, merge_parameters1)
 
         self.assertEqual(
             "oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1"
@@ -151,7 +151,7 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters2 = OAuthParameters()
         oauth_parameters_base2 = oauth_parameters2.get_base_parameters_dict()
         merge_parameters2 = oauth_parameters_base2.copy()
-        query_params2 = util.normalize_params(uri, merge_parameters2)
+        query_params2 = CoreUtils.normalize_params(uri, merge_parameters2)
 
         self.assertEqual("a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=", query_params2)
 
@@ -161,13 +161,13 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters = OAuthParameters()
         oauth_parameters_base = oauth_parameters.get_base_parameters_dict()
         merge_parameters = oauth_parameters_base.copy()
-        norm_params = util.normalize_params(url, merge_parameters)
+        norm_params = CoreUtils.normalize_params(url, merge_parameters)
 
         self.assertEqual("0=0&A=A&A=a&B=B&a=A&a=a&b=b", norm_params)
 
     def test_signature_base_string(self):
         uri = "https://api.mastercard.com"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
 
         oauth_parameters = OAuthParameters()
         oauth_parameters.set_oauth_body_hash("body/hash")
@@ -200,7 +200,7 @@ class OAuthTest(unittest.TestCase):
         oauth_parameters.set_oauth_timestamp("1111111111")
         oauth_parameters.set_oauth_version("1.0")
         oauth_parameters.set_oauth_body_hash("body/hash")
-        encoded_hash = util.base64_encode(util.sha256_encode(body))
+        encoded_hash = CoreUtils.base64_encode(CoreUtils.sha256_encode(body))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
 
         base_string = OAuth.get_base_string(url, method, oauth_parameters.get_base_parameters_dict())
@@ -227,71 +227,71 @@ class OAuthTest(unittest.TestCase):
 
     def test_url_normalization_rfc_examples1(self):
         uri = "https://www.example.net:8080"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("https://www.example.net:8080/", base_uri)
 
     def test_url_normalization_rfc_examples2(self):
         uri = "http://EXAMPLE.COM:80/r%20v/X?id=123"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("http://example.com/r%20v/X", base_uri)
 
     def test_url_normalization_redundant_ports1(self):
         uri = "https://api.mastercard.com:443/test?query=param"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_redundant_ports2(self):
         uri = "http://api.mastercard.com:80/test"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("http://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_redundant_ports3(self):
         uri = "https://api.mastercard.com:17443/test?query=param"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com:17443/test", base_uri)
 
     def test_url_normalization_remove_fragment(self):
         uri = "https://api.mastercard.com/test?query=param#fragment"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/test", base_uri)
 
     def test_url_normalization_add_trailing_slash(self):
         uri = "https://api.mastercard.com"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/", base_uri)
 
     def test_url_normalization_lowercase_scheme_and_host(self):
         uri = "HTTPS://API.MASTERCARD.COM/TEST"
-        base_uri = util.normalize_url(uri)
+        base_uri = CoreUtils.normalize_url(uri)
         self.assertEqual("https://api.mastercard.com/TEST", base_uri)
 
     def test_body_hash1(self):
         oauth_parameters = OAuthParameters()
-        encoded_hash = util.base64_encode(util.sha256_encode(OAuth.EMPTY_STRING))
+        encoded_hash = CoreUtils.base64_encode(CoreUtils.sha256_encode(OAuth.EMPTY_STRING))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
         self.assertEqual("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", encoded_hash)
 
     def test_body_hash2(self):
         oauth_parameters = OAuthParameters()
-        encoded_hash = util.base64_encode(util.sha256_encode(None))
+        encoded_hash = CoreUtils.base64_encode(CoreUtils.sha256_encode(None))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
         self.assertEqual("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", encoded_hash)
 
     def test_body_hash3(self):
         oauth_parameters = OAuthParameters()
-        encoded_hash = util.base64_encode(util.sha256_encode("{\"foõ\":\"bar\"}"))
+        encoded_hash = CoreUtils.base64_encode(CoreUtils.sha256_encode("{\"foõ\":\"bar\"}"))
         oauth_parameters.set_oauth_body_hash(encoded_hash)
         self.assertEqual("+Z+PWW2TJDnPvRcTgol+nKO3LT7xm8smnsg+//XMIyI=", encoded_hash)
 
     def test_url_encode1(self):
-        self.assertEqual("Format%3DXML", util.uri_rfc3986_encode("Format=XML"))
+        self.assertEqual("Format%3DXML", CoreUtils.uri_rfc3986_encode("Format=XML"))
 
     def test_url_encode2(self):
-        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", CoreUtils.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
 
     def test_url_encode3(self):
         self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o",
-                         util.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+                         CoreUtils.uri_rfc3986_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
 
     def test_get_oauth_nonce_param(self):
         oauth_parameters = OAuthParameters()
@@ -339,15 +339,15 @@ class OAuthTest(unittest.TestCase):
         self.assertTrue("dummy" in header)
 
     def test_percent_encoding(self):
-        self.assertEqual("Format%3DXML", util.percent_encode("Format=XML"))
-        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
-        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
-        self.assertEqual("WhqqH%2BTU95VgZ~Itpdq78BWb4cE%3D%26o", util.percent_encode("WhqqH+TU95VgZ~Itpdq78BWb4cE=&o"))
-        self.assertEqual("%2525%C2%A3%C2%A5a%2FEl%20Ni%C3%B1o%2F%25", util.percent_encode("%25£¥a/El Niño/%"))
+        self.assertEqual("Format%3DXML", CoreUtils.percent_encode("Format=XML"))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D", CoreUtils.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE="))
+        self.assertEqual("WhqqH%2BTU95VgZMItpdq78BWb4cE%3D%26o", CoreUtils.percent_encode("WhqqH+TU95VgZMItpdq78BWb4cE=&o"))
+        self.assertEqual("WhqqH%2BTU95VgZ~Itpdq78BWb4cE%3D%26o", CoreUtils.percent_encode("WhqqH+TU95VgZ~Itpdq78BWb4cE=&o"))
+        self.assertEqual("%2525%C2%A3%C2%A5a%2FEl%20Ni%C3%B1o%2F%25", CoreUtils.percent_encode("%25£¥a/El Niño/%"))
 
     def test_valid_oauth_signature_with_percent(self):
-        util.get_nonce = MagicMock(return_value='Wpe3LF09z1e3xQRI')
-        util.get_timestamp = MagicMock(return_value=1626728330)
+        CoreUtils.get_nonce = MagicMock(return_value='Wpe3LF09z1e3xQRI')
+        CoreUtils.get_timestamp = MagicMock(return_value=1626728330)
         auth_header = OAuth.get_authorization_header('https://api.mastercard.com/abc/%123/service?a=123&b=%2a2b3',
                                                      'GET', None,
                                                      'abc-abc-abc!123', OAuthTest.signing_key)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-#
 #
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/tests/test_oauth_ext.py
+++ b/tests/test_oauth_ext.py
@@ -29,89 +29,72 @@
 import unittest
 
 import hashlib
-import time
-from OpenSSL import crypto
-from requests import PreparedRequest
-from uuid import uuid4
+import re
+from unittest.mock import MagicMock
 
-import oauth1.authenticationutils as authenticationutils
+from requests import PreparedRequest
+
+import oauth1.authenticationutils as authentication_utils
 from oauth1 import coreutils as util
-from oauth1.oauth_ext import HASH_SHA256
+from oauth1.oauth import OAuth
 from oauth1.oauth_ext import OAuth1RSA
 
 
 class OAuthExtTest(unittest.TestCase):
-    signing_key = authenticationutils.load_signing_key('./test_key_container.p12', "Password1")
+    signing_key = authentication_utils.load_signing_key('./test_key_container.p12', "Password1")
     consumer_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     data = 'sensistive data'
     mock_prepared_request = PreparedRequest()
     mock_prepared_request.prepare(headers={'Content-type': 'application/json', 'Accept': 'application/json'},
                                   method="POST",
                                   url="http://www.example.com")
-    payload = {
-        'oauth_version': '1.0',
-        'oauth_nonce': str(uuid4()),
-        'oauth_timestamp': str(int(time.time())),
-        'oauth_signature_method': 'RSA-SHA256',
-        'oauth_consumer_key': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-    }
-
-    payload_ext = {'oauth_version': '1.0', 'oauth_nonce': 'xxxx213-1111-xx00-11xx-xxxx12xxxx12',
-                   'oauth_timestamp': '1111111111', 'oauth_signature_method': 'RSA-SHA256',
-                   'oauth_consumer_key': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-                   'oauth_body_hash': 'SamplEOaUthBoDYhASh', 'oauth_signature': 'OauTHSinaTUrESaMPle=='}
 
     def test_oauth_body_hash_with_body_string(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-        OAuthExtTest.mock_prepared_request.body = "{'A' : 'sensistive data'}"
+        OAuthExtTest.mock_prepared_request.body = "{'A' : 'sensitive data'}"
 
-        # Passing mock data to the actual func to get the value
-        oauth_body_hash_object = oauth_object.oauth_body_hash(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload)
+        oauth_object(OAuthExtTest.mock_prepared_request)
+        h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
-        # Using mock data to find the hash value
-        hashlib_val = hashlib.sha256(OAuthExtTest.mock_prepared_request.body.encode('utf8')).digest()
-        payload_hash_value = util.base64_encode(hashlib_val)
-
-        self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
+        self.assertEqual(h['oauth_body_hash'], 'sKrMRMpmhyMJ05fETctDp3UnlDsm1rgOJxQroerFuMs=')
 
     def test_oauth_body_hash_with_body_bytes(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         OAuthExtTest.mock_prepared_request.body = b'{"A" : OAuthExtTest.data}'
 
-        # Passing mock data to the actual func to get the value
-        oauth_body_hash_object = oauth_object.oauth_body_hash(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload)
+        oauth_object(OAuthExtTest.mock_prepared_request)
+        h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
-        # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(OAuthExtTest.mock_prepared_request.body).digest()
         payload_hash_value = util.base64_encode(hashlib_val)
 
-        self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
+        self.assertEqual(h['oauth_body_hash'], '9MoCOjWt0ke+o8ZAGij+kZ1goHpfzLIG9ZGty05eIOo=')
+        self.assertEqual(h['oauth_body_hash'], payload_hash_value)
 
     def test_oauth_body_hash_with_body_empty(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         OAuthExtTest.mock_prepared_request.body = ''
 
-        # Passing mock data to the actual func to get the value
-        oauth_body_hash_object = oauth_object.oauth_body_hash(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload)
+        oauth_object(OAuthExtTest.mock_prepared_request)
+        h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
-        # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
         payload_hash_value = util.base64_encode(hashlib_val)
 
-        self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
+        self.assertEqual(h['oauth_body_hash'], payload_hash_value)
+        self.assertEqual(h['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
 
     def test_oauth_body_hash_with_body_none(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         OAuthExtTest.mock_prepared_request.body = None
 
-        # Passing mock data to the actual func to get the value
-        oauth_body_hash_object = oauth_object.oauth_body_hash(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload)
+        oauth_object(OAuthExtTest.mock_prepared_request)
+        h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
-        # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(str("").encode('utf8')).digest()
         payload_hash_value = util.base64_encode(hashlib_val)
 
-        self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
+        self.assertEqual(h['oauth_body_hash'], payload_hash_value)
 
     def test_oauth_body_hash_with_body_empty_or_none(self):
         def prep_request():
@@ -128,16 +111,19 @@ class OAuthExtTest(unittest.TestCase):
         request_empty.body = ""
         request_none.body = None
 
-        # Passing data to the actual func to get the value
-        empty_body_hash = oauth_object.oauth_body_hash(request_empty, OAuthExtTest.payload)
-        none_body_hash = oauth_object.oauth_body_hash(request_none, OAuthExtTest.payload)
+        oauth_object(request_empty)
+        request_empty_header = OAuthExtTest.extract_oauth_params(request_empty)
 
-        # Using mock data to find the hash value
+        oauth_object(request_none)
+        request_none_header = OAuthExtTest.extract_oauth_params(request_none)
+
         empty_string_hash = hashlib.sha256(str("").encode('utf8')).digest()
         empty_string_encoded = util.base64_encode(empty_string_hash)
 
-        self.assertEqual(empty_body_hash['oauth_body_hash'], empty_string_encoded)
-        self.assertEqual(none_body_hash['oauth_body_hash'], empty_string_encoded)
+        self.assertEqual(request_empty_header['oauth_body_hash'], empty_string_encoded)
+        self.assertEqual(request_empty_header['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
+        self.assertEqual(request_none_header['oauth_body_hash'], empty_string_encoded)
+        self.assertEqual(request_none_header['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
 
     def test_oauth_body_hash_with_body_multipart(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
@@ -146,54 +132,48 @@ class OAuthExtTest(unittest.TestCase):
                              method="GET",
                              url="http://www.mastercard.com")
 
-        # Passing mock data to the actual func to get the value
-        oauth_body_hash_object = oauth_object.oauth_body_hash(mock_request, OAuthExtTest.payload)
+        oauth_object(mock_request)
+        h = OAuthExtTest.extract_oauth_params(mock_request)
 
-        # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
         payload_hash_value = util.base64_encode(hashlib_val)
 
-        self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
-
-    def test_signature(self):
-        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-        oauth_signature_object = oauth_object.signature(OAuthExtTest.data)
-        signature = util.base64_encode(crypto.sign(OAuthExtTest.signing_key, OAuthExtTest.data, HASH_SHA256))
-        self.assertEqual(signature, oauth_signature_object)
-
-    def test_helper_hash_string(self):
-        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-        hash_object = oauth_object._hash(OAuthExtTest.data)
-        self.assertEqual(hash_object,
-                         b'\xe8@\x97\xa0\x07H\x0b\xb2\x81"1\xcb\xf8\xa6@|&\xb9\xd7\xdf.\x80\xa9\x0b\xed,'
-                         b'\x8f2\x88\xd7\xf7\xe5')
-
-    def test_helper_hash_bytes(self):
-        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-        hash_object = oauth_object._hash(b"value in bytes")
-        self.assertEqual(hash_object,
-                         b'\\\n\x0e\xa3\xfe\x01\xd6T\x9fE\x97\x06\x937\x9d\\\xeaSz^\xe8\xab\xb1\xff:n\x9bY\xf5iV|')
-
-    def test_helper_hash_nonetype(self):
-        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-        hash_object = oauth_object._hash('')
-        self.assertEqual(hash_object,
-                         b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99"
-                         b"\x1bxR\xb8U")
-
-    def test_signable_message(self):
-        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-        signable_message = oauth_object.signable_message(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload_ext)
-        self.assertTrue(OAuthExtTest.mock_prepared_request.method in signable_message)
-
-    def test_helper_generate_header(self):
-        generate_header = OAuth1RSA._generate_header(OAuthExtTest.payload_ext)
-        self.assertTrue("OAuth" in generate_header)
+        self.assertEqual(h['oauth_body_hash'], payload_hash_value)
+        self.assertEqual(h['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
 
     def test_call(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         call_object = oauth_object.__call__(OAuthExtTest.mock_prepared_request)
         self.assertTrue("Authorization" in call_object.headers)
+
+    def test_ext_oauth_header_equals_to_non_ext_generated(self):
+        util.get_nonce = MagicMock(return_value=util.get_nonce())
+        util.get_timestamp = MagicMock(return_value=util.get_timestamp())
+
+        oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
+        call_object = oauth_object(OAuthExtTest.mock_prepared_request)
+
+        header = OAuth.get_authorization_header(OAuthExtTest.mock_prepared_request.url,
+                                                OAuthExtTest.mock_prepared_request.method,
+                                                OAuthExtTest.mock_prepared_request.body,
+                                                OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
+
+        self.assertTrue("Authorization" in call_object.headers)
+        self.assertEqual(header, call_object.headers['Authorization'])
+
+    @staticmethod
+    def to_pair(obj):
+        split_index = obj.index('=')
+        key = obj[:split_index]
+        value = obj[split_index + 2:]
+        return key, value[:-1]
+
+    @staticmethod
+    def extract_oauth_params(prepared_request: PreparedRequest):
+        oauth_header = prepared_request.headers['Authorization']
+        h = str(re.sub(r'^OAuth ', '', oauth_header))
+        res = dict([OAuthExtTest.to_pair(item) for item in h.split(',')])
+        return res
 
 
 if __name__ == '__main__':

--- a/tests/test_oauth_ext.py
+++ b/tests/test_oauth_ext.py
@@ -35,7 +35,7 @@ from unittest.mock import MagicMock
 from requests import PreparedRequest
 
 import oauth1.authenticationutils as authentication_utils
-from oauth1.coreutils import CoreUtils
+from oauth1 import coreutils as util
 from oauth1.oauth import OAuth
 from oauth1.oauth_ext import OAuth1RSA
 
@@ -66,7 +66,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
         hashlib_val = hashlib.sha256(OAuthExtTest.mock_prepared_request.body).digest()
-        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], '9MoCOjWt0ke+o8ZAGij+kZ1goHpfzLIG9ZGty05eIOo=')
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
@@ -79,7 +79,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
         self.assertEqual(h['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
@@ -92,7 +92,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
         hashlib_val = hashlib.sha256(str("").encode('utf8')).digest()
-        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
 
@@ -118,7 +118,7 @@ class OAuthExtTest(unittest.TestCase):
         request_none_header = OAuthExtTest.extract_oauth_params(request_none)
 
         empty_string_hash = hashlib.sha256(str("").encode('utf8')).digest()
-        empty_string_encoded = CoreUtils.base64_encode(empty_string_hash)
+        empty_string_encoded = util.base64_encode(empty_string_hash)
 
         self.assertEqual(request_empty_header['oauth_body_hash'], empty_string_encoded)
         self.assertEqual(request_empty_header['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
@@ -136,7 +136,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(mock_request)
 
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
         self.assertEqual(h['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
@@ -147,8 +147,8 @@ class OAuthExtTest(unittest.TestCase):
         self.assertTrue("Authorization" in call_object.headers)
 
     def test_ext_oauth_header_equals_to_non_ext_generated(self):
-        CoreUtils.get_nonce = MagicMock(return_value=CoreUtils.get_nonce())
-        CoreUtils.get_timestamp = MagicMock(return_value=CoreUtils.get_timestamp())
+        util.get_nonce = MagicMock(return_value=util.get_nonce())
+        util.get_timestamp = MagicMock(return_value=util.get_timestamp())
 
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         call_object = oauth_object(OAuthExtTest.mock_prepared_request)

--- a/tests/test_oauth_ext.py
+++ b/tests/test_oauth_ext.py
@@ -35,7 +35,7 @@ from unittest.mock import MagicMock
 from requests import PreparedRequest
 
 import oauth1.authenticationutils as authentication_utils
-from oauth1 import coreutils as util
+from oauth1.coreutils import CoreUtils
 from oauth1.oauth import OAuth
 from oauth1.oauth_ext import OAuth1RSA
 
@@ -66,7 +66,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
         hashlib_val = hashlib.sha256(OAuthExtTest.mock_prepared_request.body).digest()
-        payload_hash_value = util.base64_encode(hashlib_val)
+        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], '9MoCOjWt0ke+o8ZAGij+kZ1goHpfzLIG9ZGty05eIOo=')
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
@@ -79,7 +79,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = util.base64_encode(hashlib_val)
+        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
         self.assertEqual(h['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
@@ -92,7 +92,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(OAuthExtTest.mock_prepared_request)
 
         hashlib_val = hashlib.sha256(str("").encode('utf8')).digest()
-        payload_hash_value = util.base64_encode(hashlib_val)
+        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
 
@@ -118,7 +118,7 @@ class OAuthExtTest(unittest.TestCase):
         request_none_header = OAuthExtTest.extract_oauth_params(request_none)
 
         empty_string_hash = hashlib.sha256(str("").encode('utf8')).digest()
-        empty_string_encoded = util.base64_encode(empty_string_hash)
+        empty_string_encoded = CoreUtils.base64_encode(empty_string_hash)
 
         self.assertEqual(request_empty_header['oauth_body_hash'], empty_string_encoded)
         self.assertEqual(request_empty_header['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
@@ -136,7 +136,7 @@ class OAuthExtTest(unittest.TestCase):
         h = OAuthExtTest.extract_oauth_params(mock_request)
 
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = util.base64_encode(hashlib_val)
+        payload_hash_value = CoreUtils.base64_encode(hashlib_val)
 
         self.assertEqual(h['oauth_body_hash'], payload_hash_value)
         self.assertEqual(h['oauth_body_hash'], '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
@@ -147,8 +147,8 @@ class OAuthExtTest(unittest.TestCase):
         self.assertTrue("Authorization" in call_object.headers)
 
     def test_ext_oauth_header_equals_to_non_ext_generated(self):
-        util.get_nonce = MagicMock(return_value=util.get_nonce())
-        util.get_timestamp = MagicMock(return_value=util.get_timestamp())
+        CoreUtils.get_nonce = MagicMock(return_value=CoreUtils.get_nonce())
+        CoreUtils.get_timestamp = MagicMock(return_value=CoreUtils.get_timestamp())
 
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         call_object = oauth_object(OAuthExtTest.mock_prepared_request)

--- a/tests/test_oauth_ext.py
+++ b/tests/test_oauth_ext.py
@@ -30,6 +30,7 @@ import unittest
 
 import hashlib
 import re
+from importlib import reload
 from unittest.mock import MagicMock
 
 from requests import PreparedRequest
@@ -157,9 +158,15 @@ class OAuthExtTest(unittest.TestCase):
                                                 OAuthExtTest.mock_prepared_request.method,
                                                 OAuthExtTest.mock_prepared_request.body,
                                                 OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
-
+        reload(util)
         self.assertTrue("Authorization" in call_object.headers)
         self.assertEqual(header, call_object.headers['Authorization'])
+
+    def test_with_none_arguments(self):
+        oauth_object = OAuth1RSA(None, None)
+        request = PreparedRequest()
+        call_object = oauth_object(request)
+        self.assertIsNone(call_object.headers)
 
     @staticmethod
     def to_pair(obj):

--- a/tests/test_oauth_ext.py
+++ b/tests/test_oauth_ext.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-#
 #
 #
@@ -70,8 +69,8 @@ class OAuthExtTest(unittest.TestCase):
         oauth_body_hash_object = oauth_object.oauth_body_hash(OAuthExtTest.mock_prepared_request, OAuthExtTest.payload)
 
         # Using mock data to find the hash value
-        hashlib_val = hashlib.sha256((OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = util.uri_rfc3986_encode(util.base64_encode(hashlib_val))
+        hashlib_val = hashlib.sha256(OAuthExtTest.mock_prepared_request.body.encode('utf8')).digest()
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
 
@@ -84,7 +83,7 @@ class OAuthExtTest(unittest.TestCase):
 
         # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(OAuthExtTest.mock_prepared_request.body).digest()
-        payload_hash_value = util.uri_rfc3986_encode(util.base64_encode(hashlib_val))
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
 
@@ -97,7 +96,7 @@ class OAuthExtTest(unittest.TestCase):
 
         # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = util.uri_rfc3986_encode(util.base64_encode(hashlib_val))
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
 
@@ -110,7 +109,7 @@ class OAuthExtTest(unittest.TestCase):
 
         # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(str("").encode('utf8')).digest()
-        payload_hash_value = util.uri_rfc3986_encode(util.base64_encode(hashlib_val))
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
 
@@ -135,7 +134,7 @@ class OAuthExtTest(unittest.TestCase):
 
         # Using mock data to find the hash value
         empty_string_hash = hashlib.sha256(str("").encode('utf8')).digest()
-        empty_string_encoded = util.uri_rfc3986_encode(util.base64_encode(empty_string_hash))
+        empty_string_encoded = util.base64_encode(empty_string_hash)
 
         self.assertEqual(empty_body_hash['oauth_body_hash'], empty_string_encoded)
         self.assertEqual(none_body_hash['oauth_body_hash'], empty_string_encoded)
@@ -152,7 +151,7 @@ class OAuthExtTest(unittest.TestCase):
 
         # Using mock data to find the hash value
         hashlib_val = hashlib.sha256(str(OAuthExtTest.mock_prepared_request.body).encode('utf8')).digest()
-        payload_hash_value = util.uri_rfc3986_encode(util.base64_encode(hashlib_val))
+        payload_hash_value = util.base64_encode(hashlib_val)
 
         self.assertEqual(oauth_body_hash_object['oauth_body_hash'], payload_hash_value)
 
@@ -162,19 +161,12 @@ class OAuthExtTest(unittest.TestCase):
         signature = util.base64_encode(crypto.sign(OAuthExtTest.signing_key, OAuthExtTest.data, HASH_SHA256))
         self.assertEqual(signature, oauth_signature_object)
 
-    def test_get_nonce(self):
-        nonce = OAuth1RSA.nonce()
-        self.assertEqual(len(nonce), 36)
-
-    def test_get_timestamp(self):
-        timestamp = OAuth1RSA.timestamp()
-        self.assertEqual(len(str(timestamp)), 10)
-
     def test_helper_hash_string(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         hash_object = oauth_object._hash(OAuthExtTest.data)
         self.assertEqual(hash_object,
-                         b'\xe8@\x97\xa0\x07H\x0b\xb2\x81"1\xcb\xf8\xa6@|&\xb9\xd7\xdf.\x80\xa9\x0b\xed,\x8f2\x88\xd7\xf7\xe5')
+                         b'\xe8@\x97\xa0\x07H\x0b\xb2\x81"1\xcb\xf8\xa6@|&\xb9\xd7\xdf.\x80\xa9\x0b\xed,'
+                         b'\x8f2\x88\xd7\xf7\xe5')
 
     def test_helper_hash_bytes(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
@@ -186,7 +178,8 @@ class OAuthExtTest(unittest.TestCase):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)
         hash_object = oauth_object._hash('')
         self.assertEqual(hash_object,
-                         b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U")
+                         b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99"
+                         b"\x1bxR\xb8U")
 
     def test_signable_message(self):
         oauth_object = OAuth1RSA(OAuthExtTest.consumer_key, OAuthExtTest.signing_key)

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-#
 #
 #
@@ -32,22 +31,24 @@ from requests import Request
 from oauth1.signer import OAuthSigner
 import oauth1.authenticationutils as authenticationutils
 
+
 class SignerTest(unittest.TestCase):
 
     def test_sign_request(self):
         signing_key = authenticationutils.load_signing_key('./test_key_container.p12', "Password1")
         consumer_key = 'dummy'
         uri = "https://sandbox.api.mastercard.com/fraud/merchant/v1/termination-inquiry?Format=XML&PageOffset=0"
-        
+
         request = Request()
         request.method = "POST"
         request.data = ""
-            
+
         signer = OAuthSigner(consumer_key, signing_key)
         request = signer.sign_request(uri, request)
-        auth_header = request.headers['Authorization'];
+        auth_header = request.headers['Authorization']
         self.assertTrue("OAuth" in auth_header)
         self.assertTrue("dummy" in auth_header)
-       
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-#
 #
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-#
 #
 #
@@ -31,20 +30,22 @@ import unittest
 import oauth1.authenticationutils as authenticationutils
 from OpenSSL import crypto
 
+
 class UtilsTest(unittest.TestCase):
 
     def test_load_signing_key_should_return_key(self):
-        key_container_path = "./test_key_container.p12";
-        key_password = "Password1";
+        key_container_path = "./test_key_container.p12"
+        key_password = "Password1"
 
         signing_key = authenticationutils.load_signing_key(key_container_path, key_password)
         self.assertTrue(signing_key.check)
-       
+
         bits = signing_key.bits()
         self.assertEqual(bits, 2048)
 
         private_key_bytes = crypto.dump_privatekey(crypto.FILETYPE_PEM, signing_key)
         self.assertTrue(private_key_bytes)
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-#
 #
 #
-# Copyright 2019-2020 Mastercard
+# Copyright 2019-2021 Mastercard
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Description
This PR contains the following changes: 
- Code cleanup (format, indentation, ...) 
- Fix issue https://github.com/Mastercard/oauth1-signer-python/issues/35 (revert change introduced with https://github.com/Mastercard/oauth1-signer-python/pull/30)
- Fixed security hotspot [python:S2245](https://rules.sonarsource.com/python/RSPEC-2245)
- Keep the behavior consistent with other signer libs when encoding URL and params (URL and params should be percent-encoded and only query string should be encoded during params normalization)
- The OAuth1RSA module reuse the core functions instead of redefining them 
- `sha256_encode`: added support for `byte` payload
- The `oauth_signature` param in the Authorization header should be RFC-3986 encoded
- Moved `nonce` and `timestamp` generation function into the utils module 
- `get_authorization_header` method is now static 
- Improved code coverage 
- Added pycodestyle GitHub workflow and fixed sonar scan not running on pull requests