### PR TITLE
OAuthSigner.sign_request can sign Request and PreparedRequest objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Usage briefly described below, but you can also refer to the test project for ex
 
 #### Requests: HTTP for Humans™ <a name="requests"></a>
 
-You can sign [request](https://2.python-requests.org/en/v1.0.0/user/quickstart/#make-a-request) objects using the `OAuthSigner` class. 
+You can sign [request](https://docs.python-requests.org/en/latest/user/quickstart#make-a-request) objects using the `OAuthSigner` class. 
 
 Usage:
 ```python

--- a/oauth1/signer.py
+++ b/oauth1/signer.py
@@ -25,7 +25,7 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
-from requests import Request
+from requests import PreparedRequest
 
 from oauth1.oauth import OAuth
 
@@ -37,7 +37,7 @@ class OAuthSigner:
         self.signing_key = signing_key
 
     def sign_request(self, uri, request):
-        body = request.data if isinstance(request, Request) else request.body
+        body = request.body if isinstance(request, PreparedRequest) else request.data
         #  Generates the OAuth header for the request, adds the header to the request and returns the request object
         oauth_key = OAuth.get_authorization_header(uri, request.method, body, self.consumer_key,
                                                    self.signing_key)

--- a/oauth1/signer.py
+++ b/oauth1/signer.py
@@ -25,6 +25,8 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
+from requests import Request
+
 from oauth1.oauth import OAuth
 
 
@@ -35,8 +37,9 @@ class OAuthSigner:
         self.signing_key = signing_key
 
     def sign_request(self, uri, request):
+        body = request.data if isinstance(request, Request) else request.body
         #  Generates the OAuth header for the request, adds the header to the request and returns the request object
-        oauth_key = OAuth.get_authorization_header(uri, request.method, request.data, self.consumer_key,
+        oauth_key = OAuth.get_authorization_header(uri, request.method, body, self.consumer_key,
                                                    self.signing_key)
         request.headers["Authorization"] = oauth_key
         return request

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -66,7 +66,10 @@ class SignerTest(unittest.TestCase):
         signer = MCSigner(SignerTest.consumer_key, SignerTest.signing_key)
         requests.get(SignerTest.uri, auth=signer)
 
-        auth_header = mock_send.call_args.args[0].headers['Authorization']
+        auth_header = (
+            mock_send.call_args[0][0].headers if isinstance(mock_send.call_args, tuple) else mock_send.call_args.args
+            [0].headers)['Authorization']
+
         self.assertTrue("OAuth" in auth_header)
         self.assertTrue("oauth_consumer_key=\"dummy\"" in auth_header)
 


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: https://github.com/Mastercard/oauth1-signer-python/issues/38

#### Description
This PR adds functionality to `OAuthSigner.sign_request` function to support signing for [Request](https://docs.python-requests.org/en/master/api/#requests.Request) and [PreparedRequest](https://docs.python-requests.org/en/master/api/#requests.PreparedRequest) objects.

Also, fixed a broken link in the README file.

