### PR TITLE
Deprecation notice about urllib3[secure] Safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(name='mastercard-oauth1-signer',
         'Topic :: Software Development :: Libraries :: Python Modules'
         ],
       tests_require=['coverage'],
-      install_requires=['requests', 'pyOpenSSL', 'urllib3[secure]', 'Deprecated']
+      install_requires=['requests','pyOpenSSL>=0.14','urllib3', 'Deprecated']
       )


### PR DESCRIPTION
### Description
Description
pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680

Removed urllib3[secure] and updated pyOpenssl to pyOpenSSL>=0.14