### PR TITLE
Fixing the build issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyOpenSSL==22.0.0
 requests==2.22.0
 Deprecated==1.2.5
+cryptography==38.0.4


### PR DESCRIPTION
fix:  for the build issue "AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'

"cryptography 39.0.0 no longer supports openssl 1.1.0 or older and thus is causing this issue. Reference:

pyca/cryptography#7959
https://cryptography.io/en/latest/changelog/#v39-0-0 As a workaround until the dependencies are fixed, you can force install cryptography 38.0.4 and sam should work (I just verified with my CI/CD builds which all got broken today due to the cryptography update).

<!-- Please check the completed items below -->
### PR checklist

- [ ] An issue/feature request has been created for this PR
- [ ] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [ ] File the PR against the `master` branch
- [ ] The code in this PR is covered by unit tests

#### Link to issue/feature request: *add the link here*

#### Description
A clear and concise description of what is this PR for and any additional info might be useful for reviewing it.
