### PR TITLE
Fixing build issue due to pyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyOpenSSL==23.3.0
+pyOpenSSL>=22.1.0,<=23.2.0
 requests==2.27.1
 Deprecated==1.2.5
 cryptography>=39.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyOpenSSL>=22.1.0
+pyOpenSSL==23.3.0
 requests==2.27.1
 Deprecated==1.2.5
 cryptography>=39.0.0


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: *add the link here*

#### Description
Fix for the build issue:
AttributeError: module 'OpenSSL.crypto' has no attribute 'load_pkcs12'

The latest version of pyOpenSSL - version 23.3.0 (2023-10-25) has removed support for OpenSSL.crypto.load_pkcs12, which is causing this build issue. 
As a quick fix, restricting pyOpenSSL version to the previous version 23.2.0 for which this oauth signer library works.

Refer: 23.3.0 (2023-10-25) https://pypi.org/project/pyOpenSSL/
https://github.com/pyca/pyopenssl/pull/1223/files
