### PR TITLE
Update broken-links.yml

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -5,16 +5,14 @@ name: broken links?
       - "**"
   schedule:
     - cron: 0 16 * * *
-  workflow_dispatch:
+  workflow_dispatch:  
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Link Checker
-        id: lc
-        uses: peter-evans/link-checker@v1.2.2
+        uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: '-v -r *.md'
-      - name: Fail?
-        run: 'exit ${{ steps.lc.outputs.exit_code }}'
+          fail: true


### PR DESCRIPTION
Fix broken link checker action
Change link checker because old one was deprecated, and other libraries are using this one. 